### PR TITLE
fix: update stale pip/conda/Python version references in notebooks

### DIFF
--- a/00-Hello.ipynb
+++ b/00-Hello.ipynb
@@ -3,25 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "Jupyter Notebook以单元格(cell)为单位来执行其中的代码\n",
-    "\n",
-    "可以通过快捷键`SHIFT+ENTER`运行光标所在的单元格\n",
-    "\n",
-    "因为我们在调用Python 3.7内核，因此每个单元格都默认以处理Python代码的方式来编译\n",
-    "\n",
-    "这段文本内容将该单元格的属性从code改成了Markdown，因此不会按代码编译\n",
-    "\n",
-    "那么，如何具体通过执行Python代码来入门音乐科技呢？\n",
-    "\n",
-    "关于Python的基础知识，网上资源丰富，建议读者自行熟悉\n",
-    "\n",
-    "不过博主说过了要无痛入门，所以每行代码到底在做什么会给大家安排得明明白白\n",
-    "\n",
-    "另外除了Python代码，Notebook自带许多Magic操作\n",
-    "\n",
-    "比如`%matplotlib inline`就会使图像内嵌显示在这里，而非弹出一个新的窗口"
-   ]
+   "source": "Jupyter Notebook以单元格(cell)为单位来执行其中的代码\n\n可以通过快捷键`SHIFT+ENTER`运行光标所在的单元格\n\n因为我们在调用Python 3内核，因此每个单元格都默认以处理Python代码的方式来编译\n\n这段文本内容将该单元格的属性从code改成了Markdown，因此不会按代码编译\n\n那么，如何具体通过执行Python代码来入门音乐科技呢？\n\n关于Python的基础知识，网上资源丰富，建议读者自行熟悉\n\n不过博主说过了要无痛入门，所以每行代码到底在做什么会给大家安排得明明白白\n\n另外除了Python代码，Notebook自带许多Magic操作\n\n比如`%matplotlib inline`就会使图像内嵌显示在这里，而非弹出一个新的窗口"
   },
   {
    "cell_type": "markdown",
@@ -33,19 +15,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "**✎ 使用模块**\n",
-    "\n",
-    "无论是Python本身内置模块，还是之前我们通过`pip`安装好的第三方模块（例如`librosa`）\n",
-    "\n",
-    "只要安装完毕，这些模块就可以立刻通过`import`来调用\n",
-    "\n",
-    "由于我们需要通过`matplotlib.pyplot`显示图像，用`IPython.display`播放音频\n",
-    "\n",
-    "还将用到`librosa`里的方法来加载一段音频，以及`librosa.display`画波形\n",
-    "\n",
-    "以上都需要被调用："
-   ]
+   "source": "**✎ 使用模块**\n\n无论是Python本身内置模块，还是之前我们通过`uv sync`安装好的第三方模块（例如`librosa`）\n\n只要安装完毕，这些模块就可以立刻通过`import`来调用\n\n由于我们需要通过`matplotlib.pyplot`显示图像，用`IPython.display`播放音频\n\n还将用到`librosa`里的方法来加载一段音频，以及`librosa.display`画波形\n\n以上都需要被调用："
   },
   {
    "cell_type": "code",
@@ -87,11 +57,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "如果出现无法加载的问题，极大可能是因为你的电脑需要另外安装[ffmpeg](https://www.ffmpeg.org/)\n",
-    "\n",
-    "Linux和OSX系统下的conda会默认安装ffmpeg，但是Windows用户需要额外安装 "
-   ]
+   "source": "如果出现无法加载的问题，极大可能是因为你的电脑需要另外安装[ffmpeg](https://www.ffmpeg.org/)\n\nMacOS用户可通过`brew install ffmpeg`安装，Linux用户可通过`sudo apt install ffmpeg`安装，Windows用户需从官网下载并添加到系统路径"
   },
   {
    "cell_type": "markdown",

--- a/MIR-01.ipynb
+++ b/MIR-01.ipynb
@@ -222,24 +222,7 @@
      "id": "6f2e4906-6449-4fc9-98bc-866ee13d8aea"
     }
    },
-   "source": [
-    "➥ 上图来源https://en.wikipedia.org/wiki/MusicXML\n",
-    "\n",
-    "☞ 如需要对MusicXML文件进行分析，推荐使用`music21`这个第三方python库做助攻。\n",
-    "\n",
-    "在所有符号化格式中，MIDI可以说自80年代来就开始占据了C位。通过以下代码，我们来仔细看看文章最开头的音乐片段在MIDI格式中长什么样子!\n",
-    "\n",
-    "✎ 如果你已经按之前文章配置好编程环境，进入文件夹后先用`git`更新内容，再激活`py37`虚拟环境，之后我们需要另外安装一个`pretty_midi`库（安装此库也能顺便安装上`mido`），再打开`jupyter notebook`运行本文`.ipynb`文件（确保当前kernel为Python[conda env:py37]）：\n",
-    "```\n",
-    "$ cd intro2musictech\n",
-    "$ git pull\n",
-    "$ source activate py37\n",
-    "(py37)$ pip install pretty_midi\n",
-    "(py37)$ jupyter notebook\n",
-    "```\n",
-    "\n",
-    "下方代码可以将示例音乐片段对应的MIDI文件“打印”出来，可见MIDI格式的本质是遵循着一个标准技术规格（MIDI 1.0）将所有音乐中涉及的元素编码成数字数据的结构。该标准也声明了硬件和软件之间传输MIDI的协议，方便MIDI在各种合成器（synthesizer）和数字音乐工作站（DAW）之间被广泛使用。"
-   ]
+   "source": "➥ 上图来源https://en.wikipedia.org/wiki/MusicXML\n\n☞ 如需要对MusicXML文件进行分析，推荐使用`music21`这个第三方python库做助攻。\n\n在所有符号化格式中，MIDI可以说自80年代来就开始占据了C位。通过以下代码，我们来仔细看看文章最开头的音乐片段在MIDI格式中长什么样子!\n\n✎ 如果你已经按之前文章配置好编程环境，进入文件夹后先用`git`更新内容，再用`uv sync`安装依赖，之后打开`jupyter notebook`运行本文`.ipynb`文件：\n```\n$ cd intro2musictech\n$ git pull\n$ uv sync\n$ uv run jupyter notebook\n```\n\n下方代码可以将示例音乐片段对应的MIDI文件\"打印\"出来，可见MIDI格式的本质是遵循着一个标准技术规格（MIDI 1.0）将所有音乐中涉及的元素编码成数字数据的结构。该标准也声明了硬件和软件之间传输MIDI的协议，方便MIDI在各种合成器（synthesizer）和数字音乐工作站（DAW）之间被广泛使用。"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary

Updated outdated setup instructions in educational notebooks to align with the uv package manager migration.

## What Changed

### 00-Hello.ipynb
- Changed "Python 3.7" reference to "Python 3"
- Updated module installation instructions from `pip` to `uv sync`
- Replaced conda-specific ffmpeg installation note with platform-specific commands (brew for macOS, apt for Linux, manual download for Windows)

### MIR-01.ipynb
- Removed stale `py37` conda activation instructions (`source activate py37`)
- Replaced `pip install pretty_midi` with `uv sync` (pretty_midi is already in pyproject.toml)
- Updated to use `uv run jupyter notebook` for launching notebooks

## Why

These notebooks are part of the educational series for beginners. The old instructions referenced the pre-migration setup (pip, conda, Python 3.7) which no longer matches the current project workflow using uv and Python 3.10+. Keeping stale instructions confuses new users who follow the README's guidance to use uv.

## Testing

- Verified both notebooks execute without errors
- Confirmed all code cells use current librosa APIs (waveshow, not deprecated waveplot)
- Tested that uv sync correctly installs all notebook dependencies