### PR TITLE
chore: add dependabot config to exclude music-language-tutorial

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

Add `.github/dependabot.yml` to restrict Dependabot to only the root pip ecosystem, preventing it from scanning `music-language-tutorial/requirements.txt`.

That directory is a vendored translation of an external ISMIR tutorial and its dependencies are not managed by this project's `uv` setup.

Closes #16.