### PR TITLE
chore: ignore music-language-tutorial deps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # music-language-tutorial/requirements.txt — pinned for Jupyter Book v1 compatibility
+      - dependency-name: "transformers"
+      - dependency-name: "pandas"
+      - dependency-name: "scikit-learn"


### PR DESCRIPTION
## Summary
- Add ignore rules for `transformers`, `pandas`, and `scikit-learn` in dependabot config
- These packages are pinned in `music-language-tutorial/requirements.txt` for Jupyter Book v1 compatibility and should not be upgraded
- Closed PRs #21, #22, #23

## Test plan
- [x] Verify dependabot stops creating PRs for these packages