### PR TITLE
docs: add 32 WeChat article pages and index filter sidebar

### DIFF
--- a/articles/accessible-instruments.html
+++ b/articles/accessible-instruments.html
@@ -1,0 +1,282 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>「NIME-01」那些为身障人士设计的乐器 - 无痛入门音乐科技</title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「NIME-01」那些为身障人士设计的乐器</h1>
+      <div class="meta">无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            每次在电视里看到身障人士强扭着原本就不太方便的身体去演奏乐器，然后被媒体宣传成催人泪下的励志故事，我总会想，为何就不能为他们打造一款特制的乐器呢？
+          </p>
+        </blockquote>
+        <p>
+          <strong
+            >♬ 本文为NIME (New Interfaces for Musical Expression)
+            <strong>即音乐表达新接口系列</strong>的第一篇文章♬</strong
+          >
+        </p>
+        <p>
+          乐器在起源之初，作为众多日常器具的一种，本质上是为了丰富人们的生活而被发明创造的。但也正如大多数器具一样，主要为身体健全的“大多数人”所打造。再加上诸多乐器本身复杂的物理特性，不禁让人觉得“弹好一样乐器”好像就能和“聪明勤奋”划个约等号了。
+        </p>
+        <p>
+          也正因为如此，玩乐器对于多数身障人士来说更成为了一项无福消受的娱乐项目。虽然有许多机器人产品，可以通过编程让它成为自己的替身去演奏乐器。不过，相比于编程一小时听到一段生硬的音乐回放，相信大众还是喜欢自己的乐器自己弹。
+        </p>
+        <p>
+          <img
+            src="https://mmbiz.qpic.cn/mmbiz_jpg/7CrMia15fFJUFhvMicXOias9LrsEMfefe4CcHibTRSuibqCVJDNCtUZYyuyzrbXBme1OVrTDMIYYFic2U860TVyqVulg/640"
+          /><span>➥ 丰田汽车集团的机器人乐队</span>
+        </p>
+        <p>
+          那么问题来了，有些疾病导致身障人士也许连“拿住乐器”这一项动作都难以实现，如何让他们弹下去？早在1984年，『Soundbeam』团队就受到特雷门琴的启发而开发出第一款原型，并于1989年开始商业量产至今，让任何身体状况的人都能体验乐器的乐趣。它本身基于多个超声波传感器，<span
+            >每个传感器对应一种乐器音色的发生，再通过测量人与传感器之间的距离调整音高的变化。</span
+          >
+        </p>
+        <p>
+          ☟ 下面这段视频是患有成骨不全症的美国音乐家Gaelynn
+          Lea演示Soundbeam的使用。
+        </p>
+        <p>
+          <span
+            >➥ 官网链接<a
+              href="https://www.soundbeam.co.uk/"
+              target="_blank"
+              rel="noopener"
+              >https://www.soundbeam.co.uk/</a
+            ></span
+          >
+        </p>
+        <p>
+          现如今图像识别作为人工智能领域最火的任务之一，也可以在新型乐器的软件端贡献最新的研究成果。比如『Eye
+          Conductor』（眼睛指挥）就可以通过追踪眼睛的聚焦位置来判定演奏哪一个音符，再通过检测表情的变化来变换音色。
+        </p>
+        <p>
+          <img
+            src="https://mmbiz.qpic.cn/mmbiz_gif/7CrMia15fFJUFhvMicXOias9LrsEMfefe4C1EHsLmvBkt414XT3MfzXrdalmLoyplhnSHSsRf8kKmLH3t3YDCnrdw/640"
+          />
+        </p>
+        <p>
+          <span
+            >➥ 项目链接<a
+              href="https://andreasrefsgaard.dk/project/eye-conductor/"
+              target="_blank"
+              rel="noopener"
+              >https://andreasrefsgaard.dk/project/eye-conductor/</a
+            ></span
+          >
+        </p>
+        <p>
+          在硬件方面，也就是对传统乐器实打实的改造上，英国单手乐器慈善组织（The
+          OHMI
+          Trust）每年都在通过举办比赛，鼓励乐器制造者为四肢残障人士打造乐器。我们C4DM科研组的Jacob
+          Harrison博士生小哥也通过与他们的合作，在2016年打造了一款『单手贝斯』，即可以通过双脚控制音序器来设定贝斯音高，用一只手拨弦，毕竟对于贝斯手来说，右手的拨弦技巧还是非常影响最后音色的效果的！感兴趣的可以观看下方小视频。
+        </p>
+        <p>
+          <span
+            >➥ 单手贝斯详解博文<a
+              href="https://blog.bela.io/2017/02/01/making-the-one-handed-bass-with-bela/"
+              target="_blank"
+              rel="noopener"
+              >https://blog.bela.io/2017/02/01/making-the-one-handed-bass-with-bela/</a
+            ></span
+          >
+        </p>
+        <p>
+          除了改造乐器，音乐本身也是缓解某些身障疾病的一种手段，例如通过音乐干预帕金森病患者的步态等等。博主对医疗领域知之甚微，就不做过多展开了，但我相信随着神经科学领域的发展，一定会有更多振奋人心的成果！但是私心上更希望大家能理解到，“设身处地为他人着想”的这份儿心，也是促进音乐科技发展的源动力呐！
+        </p>
+        <hr />
+        <p>『参考链接』</p>
+        <p><span>☞ 英国单手乐器慈善组织</span></p>
+        <p>
+          <span
+            >➥
+            <a href="https://www.ohmi.org.uk/" target="_blank" rel="noopener"
+              >https://www.ohmi.org.uk/</a
+            ></span
+          >
+        </p>
+        <p><span>☞ 更多实例可参考下方文章</span></p>
+        <p>
+          <span
+            >➥ Larsen, Jeppe Veirum, Daniel Overholt, and Thomas B. Moeslund.
+            "The prospects of musical instruments for people with physical
+            disabilities." Proceedings of the International Conference on New
+            Interfaces for Musical Expression. 2016.</span
+          >
+        </p>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/ai-music-discovery.html
+++ b/articles/ai-music-discovery.html
@@ -1,0 +1,283 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>「MIR-05_0」震惊! AI发现这些歌竟然... - 无痛入门音乐科技</title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「MIR-05_0」震惊! AI发现这些歌竟然...</h1>
+      <div class="meta">2020年3月20日 14:20 · 无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            sorry博主今天也标题党了,&nbsp;为了接下来的几篇关于音乐自动打标的科普,&nbsp;我用现有的完完全全基于音频本身的算法,
+            根据不同流派捞取了一批歌曲, 创建了相应歌单,&nbsp;欢迎大家扫码试听!
+          </p>
+        </blockquote>
+        <section>
+          <span><strong>♬ 本文为MIR音乐信息检索系列的第9篇文章 ♬</strong></span>
+        </section>
+        <section>
+          <span
+            >本文是之后"基于音乐音频完成自动打标签"科普系列的先导文,
+            主要内容就是听歌!&nbsp;</span
+          >
+        </section>
+        <section>
+          <span
+            >以下任何一张歌单里的所有歌曲,
+            都是用<strong>完全基于音频信号的算法</strong>根据标题里的流派信息,
+            活生生地捞出来的,
+            <strong>没有任何其他信息或人工的干预</strong
+            >!&nbsp;里面不少歌博主自己是从来没有听过.</span
+          >
+        </section>
+        <section><span>来吧! 扫码听歌!&nbsp;(共8张歌单8个图)</span></section>
+        <p>
+          <img
+            data-original-style=""
+            data-index="2"
+            src="https://mmbiz.qpic.cn/mmbiz_jpg/7CrMia15fFJVHQfLWNSesdJR5EwDU1ibgianyddD6LDibqkfHoXkTeoCKDkRuiaq7Gib60Pa5wk8AnS39UCU00tWjBlw/640"
+            _width="677px"
+            alt="Image"
+            data-report-img-idx="0"
+          />
+        </p>
+        <p>
+          <img
+            data-original-style=""
+            data-index="3"
+            src="https://mmbiz.qpic.cn/mmbiz_jpg/7CrMia15fFJVHQfLWNSesdJR5EwDU1ibgiaZY0GYUol3a5Vda0ZKIibVpAG8536ezk2oBIic8LxvjDWiaDOcTnDC9lqA/640"
+            _width="677px"
+            alt="Image"
+          />
+        </p>
+        <p>
+          <img
+            data-original-style=""
+            data-index="4"
+            src="https://mmbiz.qpic.cn/mmbiz_jpg/7CrMia15fFJVHQfLWNSesdJR5EwDU1ibgiaSgYeNQeIAHp4VUxOdjLuJH7Ze0HficozDicRluBozJVSIiaUbMfrJQX7g/640"
+            _width="677px"
+            alt="Image"
+          />
+        </p>
+        <p>
+          <img
+            data-original-style=""
+            data-index="5"
+            src="https://mmbiz.qpic.cn/mmbiz_jpg/7CrMia15fFJVHQfLWNSesdJR5EwDU1ibgia67evLiaBBsfSY2CvNWfRadzdjTHov5cHuC7ut9Z4EfkfqtTicoRnY9XA/640"
+            _width="677px"
+            alt="Image"
+          />
+        </p>
+        <p>
+          <img
+            data-original-style=""
+            data-index="6"
+            src="https://mmbiz.qpic.cn/mmbiz_jpg/7CrMia15fFJVHQfLWNSesdJR5EwDU1ibgiaTMKKF05VC6vaSmmwVPN2raAQJRaWXIg23ftXicTibqb3BEcdOibtDJh2A/640"
+            _width="677px"
+            alt="Image"
+          />
+        </p>
+        <p>
+          <img
+            data-original-style=""
+            data-index="7"
+            src="https://mmbiz.qpic.cn/mmbiz_jpg/7CrMia15fFJVHQfLWNSesdJR5EwDU1ibgia7W14oRHdgH7yD4xyBBtpZqTwK9XxsbrK5g8Umyz0dJe6j1fjFsibhiaA/640"
+            _width="677px"
+            alt="Image"
+          />
+        </p>
+        <p>
+          <img
+            data-original-style=""
+            data-index="8"
+            src="https://mmbiz.qpic.cn/mmbiz_jpg/7CrMia15fFJVHQfLWNSesdJR5EwDU1ibgia5J2q22nQWiaGQKEicxhicynAh8KteGTkdDLDOHnJqtx1IKC0Cl7T8hqNw/640"
+            _width="677px"
+            alt="Image"
+          />
+        </p>
+        <p>
+          <img
+            data-original-style=""
+            data-index="9"
+            src="https://mmbiz.qpic.cn/mmbiz_jpg/7CrMia15fFJVHQfLWNSesdJR5EwDU1ibgiat15GDhsGONJMzMcGlrOLl9iaSH1k8pZhzNAxhxQNwyK5iblMNU59ercQ/640"
+            _width="677px"
+            alt="Image"
+          />
+        </p>
+        <section><span></span><br /></section>
+        <hr />
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/ai-paper-reader.html
+++ b/articles/ai-paper-reader.html
@@ -1,0 +1,350 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>
+      「TECH」过年好！分享一个可速度分析AI论文的技能指令: /ai-paper-reader -
+      无痛入门音乐科技
+    </title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>
+        「TECH」过年好！分享一个可速度分析AI论文的技能指令: /ai-paper-reader
+      </h1>
+      <div class="meta">2026年2月15日 17:05 · 无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            <span leaf=""
+              >分享我在Claude Code中经常使用到的一个技能<span textstyle=""
+                >/ai-paper-reader</span
+              >，只需要声明想了解的AI论文的PDF文件路径，就可以生成该论文的阅读笔记。</span
+            >
+          </p>
+        </blockquote>
+        <section>
+          <span
+            ><span leaf=""
+              >本文将以英文论文为例，输出中文的阅读笔记。原论文是arXiv上的一篇5页文章，已发表在2025年的INTERSPEECH上。</span
+            ></span
+          >
+        </section>
+        <section>
+          <pre
+            data-lang="perl"
+          ><code><span leaf=""><span>@misc</span>{özer2025comprehensiverealworldassessmentaudio,</span></code><code><span leaf="">&nbsp; &nbsp; &nbsp; title={A Comprehensive Real-World Assessment of Audio Watermarking Algorithms: Will They Survive Neural Codecs?},&nbsp;</span></code><code><span leaf="">&nbsp; &nbsp; &nbsp; author={Yigitcan Özer&nbsp;<span>and</span>&nbsp;Woosung Choi&nbsp;<span>and</span>&nbsp;Joan Serrà&nbsp;<span>and</span>&nbsp;Mayank Kumar Singh&nbsp;<span>and</span>&nbsp;Wei-Hsiang Liao&nbsp;<span>and</span>&nbsp;Yuki Mitsufuji},</span></code><code><span leaf="">&nbsp; &nbsp; &nbsp; year=<span>{2025}</span>,</span></code><code><span leaf="">&nbsp; &nbsp; &nbsp; eprint={<span>2505.19663</span>},</span></code><code><span leaf="">&nbsp; &nbsp; &nbsp; archivePrefix=<span>{arXiv}</span>,</span></code><code><span leaf="">&nbsp; &nbsp; &nbsp; primaryClass={cs.SD},</span></code><code><span leaf="">&nbsp; &nbsp; &nbsp; url={https:<span>//arxi</span>v.org/<span>abs</span>/<span>2505.19663</span>},&nbsp;</span></code><code><span leaf="">}</span></code></pre>
+        </section>
+        <hr />
+        <h3><span leaf="">『Claude Code界面』</span></h3>
+        <p>
+          <span><span leaf="">先让CC解释一下这个技能:</span></span>
+        </p>
+        <section nodeleaf="">
+          <img
+            data-aistatus="1"
+            type="block"
+            data-original-style="null"
+            data-index="2"
+            src="https://mmbiz.qpic.cn/sz_mmbiz_png/FJfic83TmLLtyckZxbQudqoyMOLjdib8IZPE8Oiaib9R40LVoWU8jbLibaLlmSXibSaeMZ7owtlsxwUmm2l7MgWFQyj4Yw3MoJqz84ZjKKAPR3yCY/640"
+            _width="677px"
+            alt="Image"
+            data-report-img-idx="0"
+          />
+        </section>
+        <section>
+          <span leaf=""
+            >之后直接输入以下指令（我对原版指令进行了修改，使其能输出中文或英文的笔记）：</span
+          >
+        </section>
+        <section>
+          <pre
+            data-lang="css"
+          ><code><span leaf="">/ai-paper-reader&nbsp;<span>--lang</span>&nbsp;zh&nbsp;<span>@2025-eval-watermark</span>.pdf</span></code></pre>
+        </section>
+        <section>
+          <span leaf="">✎ 以下为指令运行后的截图</span
+          ><span
+            ><section nodeleaf="">
+              <img
+                data-aistatus="1"
+                type="block"
+                data-original-style="null"
+                data-index="3"
+                src="https://mmbiz.qpic.cn/sz_mmbiz_png/FJfic83TmLLuqPria1g6EzLLpO8xgxwm75ZknyPWSlt0f4LJxCtLibuaiaJ8IQ9XGZ8jtRdGiaVwK6exbEAWoWDC1SYHnSRTtjg5NSfuXqq7riavc/640"
+                _width="677px"
+                alt="Image"
+              /></section
+          ></span>
+        </section>
+        <hr />
+        <h3><span leaf="">『阅读笔记』</span></h3>
+        <p>
+          <span
+            ><span leaf=""
+              >不到3分钟生成的阅读笔记为markdown格式，我可以继续让CC将其保存为其他格式，以下是笔记另存为HTML后的长截图：</span
+            ></span
+          >
+        </p>
+        <section nodeleaf="">
+          <img
+            data-aistatus="1"
+            type="block"
+            data-original-style="null"
+            data-index="4"
+            src="https://mmbiz.qpic.cn/mmbiz_png/FJfic83TmLLvd5nsjNctvU2SRsY0hQP0CLbnWoYEzWviaWQWptpUAickjcasxO1XqiaLibcv2bLI0bibPbvVFvMpT4AdbOiaib2aeAvNp2z5vSEWk4U/640"
+            _width="677px"
+            alt="Image"
+          />
+        </section>
+        <hr />
+        <p>
+          <span
+            ><span leaf=""
+              >阅读笔记的质量还是不错的，原版的<span textstyle=""
+                >/ai-paper-reader</span
+              >我是直接通过skill.fish安装的，这里建议在安装第三方的skill或command或plugin时，还是要检查一下有没有prompt
+              injection等风险。</span
+            ></span
+          ><span
+            ><span leaf=""><br /></span
+          ></span>
+        </p>
+        <p>
+          <span
+            leaf=""
+            data-pm-slice='1 1 ["para",{"tagName":"section","attributes":{"style":"margin-top: 15px; margin-bottom: 15px; box-sizing: border-box; font-size: 16px; white-space: pre-line; line-height: 1.5em; color: rgb(74, 74, 74); font-family: Avenir, -apple-system-font, 微软雅黑, sans-serif;"},"namespaceURI":""}]'
+            >✎&nbsp;</span
+          ><span leaf=""
+            ><a
+              href="https://mcpmarket.com/tools/skills/ai-paper-reader"
+              target="_blank"
+              rel="noopener"
+              >https://mcpmarket.com/tools/skills/ai-paper-reader</a
+            ></span
+          >
+        </p>
+        <p>
+          <strong
+            ><span
+              ><span leaf=""><span textstyle="">上文回顾：</span></span></span
+            ></strong
+          >
+        </p>
+        <ul>
+          <li>
+            <p>
+              <span leaf=""
+                ><a
+                  target="_blank"
+                  href="https://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247484022&amp;idx=1&amp;sn=94535fbc6c7a56490dd52d11f0962f4d&amp;scene=21#wechat_redirect"
+                  textvalue="「INFO」连接音乐音频与自然语言"
+                  data-itemshowtype="0"
+                  linktype="text"
+                  data-linktype="2"
+                  link-id="1392"
+                  ><span textstyle="">「INFO」连接音乐音频与自然语言</span></a
+                ></span
+              ><span leaf=""><br /></span>
+            </p>
+          </li>
+          <li>
+            <p>
+              <span leaf=""
+                ><a
+                  target="_blank"
+                  href="https://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247484015&amp;idx=1&amp;sn=ffb0e282814654db668b9aeaae7070e6&amp;scene=21#wechat_redirect"
+                  textvalue="「MIR-CC」2026年用Claude Code就可以无痛入门音乐科技"
+                  data-itemshowtype="0"
+                  linktype="text"
+                  data-linktype="2"
+                  link-id="9b8f"
+                  ><span textstyle=""
+                    >「MIR-CC」2026年用Claude Code就可以无痛入门音乐科技</span
+                  ></a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <section>
+          <span leaf=""
+            >我平时工作时还会用到很多软件开发相关的指令、技能、插件、MCP、甚至是bot，和这个公众号的音乐科技主题关联没那么密切，但感兴趣的朋友欢迎关注我的GitHub，查看最近星标的repo。</span
+          ><span data-pm-slice="0 0 []"
+            ><strong
+              ><span leaf=""><br /></span></strong
+          ></span>
+        </section>
+        <p><mp-style-type data-value="3"></mp-style-type></p>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/audio-embedding.html
+++ b/articles/audio-embedding.html
@@ -1,0 +1,487 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>
+      「MIR-05_2」当音乐标签化身为音频Embedding时能解决什么？ - 无痛入门音乐科技
+    </title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「MIR-05_2」当音乐标签化身为音频Embedding时能解决什么？</h1>
+      <div class="meta">2021年6月4日 19:14 · 无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            无论是信号处理还是机器学习，基于歌曲音频做自动打标的最终输出总是明确的音乐标签，但在运算过程的中间产物也大有其发挥天地，你可以说它是特征向量、或是一种音乐表征、或用当前我甚至不知道中文翻译是什么的流行叫法：Embedding。<br />
+          </p>
+        </blockquote>
+        <section>
+          <span
+            ><strong>♬ 本文为MIR音乐信息检索系列的第11篇文章 ♬</strong></span
+          >
+        </section>
+        <section>
+          <span>在之前的文章</span
+          ><a
+            target="_blank"
+            href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483885&amp;idx=1&amp;sn=f9e4c9f71451575d1111e566943f4aff&amp;chksm=fe0d9f42c97a16544b35edd490294e754e9e3cf48a13ca6585bcb7f58c02d0c1bf0222822793&amp;scene=21#wechat_redirect"
+            data-itemshowtype="0"
+            tab="innerlink"
+            data-linktype="2"
+            hasload="1"
+            ><span>「MIR-04」音乐推荐: 努力懂你的预言家</span></a
+          ><span
+            >博主有简单介绍，每个歌曲可以用Embedding即推荐模型中的特征向量来隐晦地表示多维度的信息，再通过计算某用户喜欢过的歌曲与众多未听歌曲的Embedding之间的相似程度，来召回相似程度大的歌曲进行推荐。</span
+          >
+        </section>
+        <section>
+          <span
+            >输出Embedding的推荐模型，在训练过程中采用的是大量用户行为数据，在音乐推荐这个场景中就是听歌历史、收藏/扎心歌曲、关注某些歌手等等。那么问题来了，新歌和冷门歌曲没有多少与用户的互动，这些歌曲的Embedding不能充分的代表歌曲本身，也就不能真正地找到相似歌曲，在推荐时就面临了“内容冷启动”的问题。</span
+          >
+        </section>
+        <section>
+          <span
+            >这时我们就需要一种从音频内容本身出发的新型Embedding，音乐它就算再怎么缺乏metadata少了各种标签，也总会有音频存在（别拿John
+            Cage的4'3''抬杠）。2020年我在腾讯音乐工作时，和推荐团队的朋友们一起开发了各种以音频为输入的Embeddings，实现论文专利双丰收。博主将用以下三部分简单解读下研发过程</span
+          ><span>：</span>
+        </section>
+        <ul>
+          <li>
+            <section><span>可以解释的Audio Embedding</span></section>
+          </li>
+          <li>
+            <section>
+              <span
+                >难以解释的User Audio Embedding
+                (在今年ICASSP大会上有线上演讲)</span
+              >
+            </section>
+          </li>
+          <li>
+            <section><span>Embedding作为特征在各类MIR任务的应用</span></section>
+          </li>
+        </ul>
+        <hr />
+        <h3>『Audio Embedding』</h3>
+        <p>
+          <span
+            >之所以是“可以解释的”，因为在构建Embedding之前已经设定好需要从音频中获取哪些类信息，即<span>属性（表示歌曲是唱是说是纯音乐等</span>）和流派（10类具有区分度的</span
+          ><span
+            >大类流派）。因此研发的重点更多落在了如何分别训练可区分流派和属性的音频模型，这里可参考前一篇文章</span
+          ><a
+            target="_blank"
+            href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483923&amp;idx=1&amp;sn=2fe1ad96ba0b764888f28fdd88ce9e36&amp;chksm=fe0d9cbcc97a15aa70632d73d3d7cafbc63d97027d8a9d1ecd7fee20212649d6b1fbde37c90f&amp;scene=21#wechat_redirect"
+            data-itemshowtype="0"
+            tab="innerlink"
+            data-linktype="2"
+            ><span>「MIR-05_1」音乐流派自动识别的前世今生</span></a
+          ><span
+            >。在这个步骤之后，对于任意1首歌曲，其每3秒都会得到14个值（4个属性与10个流派），那么沿着时间轴得到的整个“14
+            x N个3秒片段”矩阵画出来，就会如下图所示：</span
+          >
+        </p>
+        <p>
+          <img
+            data-galleryid=""
+            data-original-style=""
+            data-index="2"
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJVHEWelsvBVpzfZH8H0bzWtlWQPJeJBuibiaRcJAToxdnYnAj4bz5V5yMt6TatR2kYLw7MlThm2zicbQ/640"
+            _width="677px"
+            alt="Image"
+          />
+        </p>
+        <p>
+          <span></span><span>这个图</span
+          ><span>的音频输入是周杰伦的《以父之名</span><span>》，</span
+          ><span>如果你还记得这首嘻哈说</span
+          ><span>唱和R&amp;B演唱等元素兼</span><span>有</span><span>的好</span
+          ><span>歌，</span><span>就也能发现上图中</span><span>某些时段内</span
+          ><span
+            >，<span>vocal w/ acc (人声带伴奏</span
+            ><span>)&nbsp;</span>以及rap和rhythm对应的值很高亮</span
+          ><span>。</span>
+        </p>
+        <p>
+          <span
+            >但每首歌的时长不定，如何将<span>“</span><span>14</span
+            ><span> x N</span><span>个</span><span>3秒片段</span><span>”</span
+            ><span>矩阵</span
+            >再降维到统一维度的特征，作为Embedding供推荐系统使用，我们非常直接的取了6大描述性统计值，比如对rap维度沿时间轴的N个值取其最大值、最小值、均值、方差、峰度、偏度，因此每首歌最终能被表示为“14
+            x 6”的Audio Embedding。</span
+          >
+        </p>
+        <p>
+          <span
+            >之后融合到推荐系统中测试对新歌的推荐是否管用，我们采用了线上A/B
+            Test，的确对于新歌在保证播放量的前提下同时提升完播率</span
+          ><span
+            >有显著作用。整套架构“丘比特—QQ音乐新歌精准投放系统”也在刚刚过去的QCon全球软件开发大会上，由我们数据科学团队负责人李一凡博士进行了介绍。</span
+          >
+        </p>
+        <p>
+          <span
+            >✎ 论文：Beici Liang, Zonghan Cai, Quan Chen, Yifan Li, Minwei Gu.
+            ”Novel Audio Embeddings for Personalized Recommendations on Newly
+            Released Tracks”, <span>in Proceedings of the</span> Machine
+            Learning for Media Discovery Workshop (ML4MD) at the&nbsp;37th
+            International Conference on Machine Learning (ICML), 2020.</span
+          >
+        </p>
+        <p>
+          <span
+            >☞ ICML演讲：<a
+              href="https://slideslive.com/38931318/novel-audio-embeddings-for-personalized-recommendations-on-newly-released-tracks?ref=speaker-36496-latest"
+              target="_blank"
+              rel="noopener"
+              >https://slideslive.com/38931318/novel-audio-embeddings-for-personalized-recommendations-on-newly-released-tracks?ref=speaker-36496-latest</a
+            ></span
+          >
+        </p>
+        <p>
+          <span
+            ><span>☞</span
+            ><span
+              >&nbsp;QCon介绍：<a
+                href="https://qcon.infoq.cn/2021/beijing/presentation/3312"
+                target="_blank"
+                rel="noopener"
+                >https://qcon.infoq.cn/2021/beijing/presentation/3312</a
+              ></span
+            ></span
+          >
+        </p>
+        <hr />
+        <h3>『User Audio Embedding』</h3>
+        <p>
+          <span
+            >上部分的Embedding由于规定好对流派和属性信息的捕捉，难免遗漏掉其他未被定义的音乐信息。更何况人类对于音乐的偏好，确实难以用具体的维度量化。与其定义好更多的维度，不如直接拿音频训练一个模型，使其输出去拟合之前“基于用户行为训练出的推荐模型”得到的User
+            Embedding (UE)。这种结合用户信息得到的新型音频输出，我们命名为User
+            Audio Embedding
+            (UAE)，相当于让大量的用户行为信息去定义音频模型到底应该学出什么，所以“难以解释”（这是陈轲同学在跟我实习期间的主要工作，不愧是UCSD的博士生，完成度相当高）。</span
+          >
+        </p>
+        <p>
+          <span
+            >所以第一步，我们要拿到UE（感谢推荐算法高级工程师马小栓的鼎力相助！）。这里可参考YoutubeDNN的模型架构和训练策略，但数据替换为音乐场景，如下图所示：</span
+          >
+        </p>
+        <p>
+          <img
+            data-galleryid=""
+            data-original-style=""
+            data-index="3"
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJVHEWelsvBVpzfZH8H0bzWtCjqcLCtzZujdwX0s1eD8ez8ahVM0AR9fL2zrft4fIsXtw3aNOYfTVw/640"
+            _width="677px"
+            alt="Image"
+          />
+        </p>
+        <p>
+          <span
+            >已知每个用户的UE，及其最近加心/收藏以及拉黑/快速切过的正负反馈歌曲，采用metric
+            learning构建下图所示的网络，训练时我们需要将正反馈与UE的乘积vs负反馈与UE的乘积，离得越远越好：</span
+          >
+        </p>
+        <p>
+          <img
+            data-original-style=""
+            data-index="4"
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJVHEWelsvBVpzfZH8H0bzWtvYTvZ1ictLsFZ6JooBrUyo4AwSTRjtHFibYsIv5cafg1Motf9lPg1xCg/640"
+            _width="677px"
+            alt="Image"
+          />
+        </p>
+        <p>
+          <span
+            >模型训练完毕，我们即可得到一个网络，对于任何音频输入，都能输出相应的UAE。它在音乐推荐离线任务上的表现，可详见论文。如果有参加ICASSP的同僚，也可以线上听我们做详细的讲演，具体会议信息如下。</span
+          ><br />
+        </p>
+        <section>
+          <span
+            >✎ 论文：Ke Chen, Beici Liang, Xiaoshuan Ma, Minwei Gu. ”Learning
+            Audio Embeddings with User Listening Data for Content-based Music
+            Recommendation”, in Proceedings of the IEEE International Conference
+            on Audio, Speech and Signal Processing (ICASSP), 2021.</span
+          ><br />
+        </section>
+        <section>
+          <span
+            >☞ PDF可见：<a
+              href="https://arxiv.org/pdf/2010.15389.pdf"
+              target="_blank"
+              rel="noopener"
+              >https://arxiv.org/pdf/2010.15389.pdf</a
+            ></span
+          >
+        </section>
+        <section>
+          <span
+            ><span>☞ ICASSP线上信息</span
+            ><span
+              >：2021年6月8号多伦多时间16:30-17:15
+              (北京时间为9号凌晨04:30-05:15)，MLSP-10 Deep Learning for Speech
+              and Audio</span
+            ></span
+          ><span></span>
+        </section>
+        <hr />
+        <h3>『在MIR任务中的应用』</h3>
+        <p>
+          <span
+            >虽然难以解释UAE各个维度上代表的语义，但我们可以把它应用到具体的MIR任务中，试探其功效。比如单纯用musicnn模型的特征
+            vs.
+            额外加上UAE，来比对这些特征在流派识别上的效果，确实加上UAE的精确度更高。我们也用这个方案参加了2020年的MIREX竞赛，综合指标达到0.7474，且对于乡村
+            (country)、说唱 (rap/hip-hop)、韩国流行 (K-pop ballad)
+            这三类的检测可达历史最高分。</span
+          >
+        </p>
+        <p>
+          <span
+            ><span
+              >☞ MIREX竞赛结果：<a
+                href="https://www.music-ir.org/nema_out/mirex2020/results/act/mixed_report/"
+                target="_blank"
+                rel="noopener"
+                >https://www.music-ir.org/nema_out/mirex2020/results/act/mixed_report/</a
+              ></span
+            ><span></span
+          ></span>
+        </p>
+        <p>
+          <span
+            >Embedding这个概念本身可以说是音乐内容的一种表达形式，既可如音频指纹一样精细，也可以像音乐流派一样笼统。处于中等颗粒度的Embedding已经被运用到翻唱检测、歌手识别等任务中，当每个音频可以被定长的Embedding表示时，之后在大规模数据中做快速检索便易如反掌。我在腾讯音乐最后发表的论文就是关于歌手识别。</span
+          >
+        </p>
+        <p>
+          <span><span>✎ 论文</span></span
+          ><span
+            >：Shichao Hu, Beici Liang, Zhouxuan Chen, Xiao Lu, Ethan Zhao,
+            Simon Lui. ”Large-scale Singer Recognition using Deep Metric
+            Learning”, accepted to the IEEE International Joint Conference on
+            Neural Networks (IJCNN), 2021.</span
+          >
+        </p>
+        <hr />
+        <section>
+          <span
+            >最后说点题外话，在腾讯音乐工作期间能做这么多音频Embedding的研发和落地，非常感谢推荐团队负责人aka音乐科技届前辈顾旻玮让我自由发挥无限折腾，以及丘比特项目的配合（尤其感谢宗颔/陈全/孙寒的技术支持和彭蔚的策略把控）。你们和申申、鲁霄、凡哥、曹翔、Mark以及泽堉，在无数个充满音乐和咖啡的午休和周末里对我的鼓励，是我在深圳最大的快乐。</span
+          >
+        </section>
+        <section>
+          <span
+            >离职但不离业，我还会在全球范围的音乐科技界活跃，公众号也许还是更新得很慢（谢谢近2000位关注者）。参加今年ICASSP的朋友们，欢迎来线上聊天！</span
+          >
+        </section>
+        <p>
+          <strong><span>上文回顾：</span></strong>
+        </p>
+        <ul>
+          <li>
+            <p>
+              <a
+                target="_blank"
+                href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483898&amp;idx=1&amp;sn=3a405119a32714442c8dcd9be830cdb9&amp;chksm=fe0d9f55c97a1643a091acb7d6c25c14a8d19d107f9d430ffd9055a468f4d18c43666b2c260f&amp;scene=21#wechat_redirect"
+                data-itemshowtype="0"
+                tab="innerlink"
+                data-linktype="2"
+                ><span>「MIR-05_0」震惊! AI发现这些歌竟然...</span></a
+              ><br />
+            </p>
+          </li>
+          <li>
+            <p>
+              <a
+                target="_blank"
+                href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483923&amp;idx=1&amp;sn=2fe1ad96ba0b764888f28fdd88ce9e36&amp;chksm=fe0d9cbcc97a15aa70632d73d3d7cafbc63d97027d8a9d1ecd7fee20212649d6b1fbde37c90f&amp;scene=21#wechat_redirect"
+                data-itemshowtype="0"
+                tab="innerlink"
+                data-linktype="2"
+                >「MIR-05_1」音乐流派自动识别<span>的前世今生</span></a
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <a
+                target="_blank"
+                href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483885&amp;idx=1&amp;sn=f9e4c9f71451575d1111e566943f4aff&amp;chksm=fe0d9f42c97a16544b35edd490294e754e9e3cf48a13ca6585bcb7f58c02d0c1bf0222822793&amp;scene=21#wechat_redirect"
+                data-itemshowtype="0"
+                tab="innerlink"
+                data-linktype="2"
+                ><span>「MIR-04」音乐推荐: 努力懂你的预言家</span></a
+              >
+            </p>
+          </li>
+        </ul>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/audio-feature-frequency.html
+++ b/articles/audio-feature-frequency.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>「MIR-02_3」音频特征小全之频域特征 - 无痛入门音乐科技</title>
+  <style>
+    :root {
+      --bg: #f5f5f7;
+      --card-bg: #ffffff;
+      --text: #1d1d1f;
+      --text-secondary: #6e6e73;
+      --accent: #5856d6;
+      --border: #d2d2d7;
+      --code-bg: #f0f0f3;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0d0d12;
+        --card-bg: #1c1c24;
+        --text: #f0f0f5;
+        --text-secondary: #8e8e93;
+        --accent: #7b79ff;
+        --border: #2c2c34;
+        --code-bg: #15151d;
+      }
+    }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", Roboto, "Noto Sans SC", sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.8;
+    }
+    .header {
+      background: linear-gradient(135deg, #0f0c29 0%, #302b63 50%, #24243e 100%);
+      padding: 2rem 1.5rem;
+      text-align: center;
+    }
+    .header a {
+      color: rgba(255,255,255,0.7);
+      text-decoration: none;
+      font-size: 0.9rem;
+    }
+    .header a:hover { color: #fff; }
+    article {
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem 4rem;
+    }
+    article h1 {
+      font-size: 1.8rem;
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+      line-height: 1.3;
+    }
+    .meta {
+      color: var(--text-secondary);
+      font-size: 0.85rem;
+      margin-bottom: 2rem;
+      padding-bottom: 1rem;
+      border-bottom: 1px solid var(--border);
+    }
+    .content { font-size: 1rem; }
+    .content p,
+      .content section { margin-bottom: 1rem; }
+    .content img {
+      max-width: 100%;
+      height: auto;
+      border-radius: 8px;
+      margin: 1rem 0;
+    }
+    .content h2, .content h3 {
+      text-align: center;
+      margin: 1.5rem 0 0.8rem;
+      font-weight: 600;
+    }
+    .content blockquote {
+      border-left: 3px solid var(--accent);
+      padding-left: 1rem;
+      color: var(--text-secondary);
+      margin: 1rem 0;
+    }
+    .content a { color: var(--accent); }
+    .content hr {
+      border: none;
+      border-top: 1px solid var(--border);
+      margin: 1.5rem 0;
+    }
+    .content ul, .content ol {
+      padding-left: 1.5rem;
+      margin-bottom: 1rem;
+    }
+    .content li { margin-bottom: 0.3rem; }
+    .content table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1rem 0;
+    }
+    .content th, .content td {
+      border: 1px solid var(--border);
+      padding: 0.5rem;
+      text-align: left;
+    }
+    .content pre, .content code {
+      font-family: "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+      font-size: 0.85em;
+    }
+    .content code {
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 0.15rem 0.4rem;
+    }
+    .content pre {
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1rem 1.2rem;
+      overflow-x: auto;
+      margin: 1rem 0;
+      line-height: 1.5;
+    }
+    .content pre code {
+      background: none;
+      border: none;
+      padding: 0;
+      font-size: inherit;
+      display: block;
+    }
+    .content pre ol {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+    .content pre li {
+      margin: 0;
+      padding: 0;
+    }
+    .content pre p {
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+  </div>
+  <article>
+    <h1>「MIR-02_3」音频特征小全之频域特征</h1>
+    <div class="meta">无痛入门音乐科技</div>
+    <div class="content">
+      <blockquote><p>频域特征(spectral feature)是将音频波形变换到频域之后得出的一系列基于频谱的指标。</p></blockquote><p><span><strong>♬ 本文为MIR音乐信息检索系列的第2.3篇文章 ♬</strong></span></p><p><span><strong>♬ 该文与2.1概览+2.2时域特征及后续2.X文章共同组成音频特征小全 ♬</strong></span></p><p><span>本文将主要讲解以下频域特征及其简单应用：</span></p><ul><li><p><span>为什么用频谱质心的高低来衡量乐器声音的亮暗？</span></p></li><li><p><span>如何用频谱差分幅度得出一个个乐音开始演奏的时刻？</span></p></li><li><p><span>大名鼎鼎的MFCC到底是什么？</span></p></li></ul><hr><h3>『回顾音色』</h3><p>前文2.2提到时域包络的差异是帮助我们理解“不同乐器有不同音色”的助手之一，其他助手集中在频域。这个不是我瞎说的，而是早在90年代左右就有心理声学学者给志愿者们听许多对儿乐器声音，并让他们给这一对对声音在音色上的不相似程度打分，最后用数学建模估计出大致可以用多少个维度来共同表示出人们如何区分不同音色，实验过程如下图：</p><p><img src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJXmNvSXgEbnw32vmks2Wov6AA4vOFRv5KZUGia6EWXSoQneiaGwvtIgjZ11tT3bClzlaoZjCbGPms0w/640"></p><p>✎ McAdam在1995年发表的论文中指出，可以用以下3个维度来表示音色空间：起音的时间（详见上文2.2），频谱质心，频谱差分幅度。后两者就是本文频域特征的两大主角儿。</p><p><img src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJXmNvSXgEbnw32vmks2Wov6I92kN9a4Nys2icBd3GwEwic9hGf7djicpSaxrLia4uxOJQmib0IpGgNJyxA/640"></p><hr><h3>『频谱质心』</h3><p>频谱质心(spectral centroid)可表示频谱X中的能量大致平均集中在哪个频率附近，数学计算公式为：</p><p><img src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJXmNvSXgEbnw32vmks2Wov66dsSUM9wyfmlDJT7cXOKRM9EicruibYlJibnUNNaEV0SKtPz6eYI3b3Rw/640"></p><p>其中|X(k)|指频谱在第k个频点上的幅度值，f(k)则为第k个频点对应的频率值，<br></p><p>即使是同样音高的音符，不同乐器每个音上泛音能量的分布不一样，则各个音在“听上去相对明亮的乐器”中大部分能量分布在频率较高的区域，那么频谱质心的值当然就更高。我们用下方音频为例，可看到演奏同音高的音符时，钢琴vs羽管键琴在频谱质心上数值的变化。</p><p></mpvoice></p><p>我们可以直接调用librosa中计算频谱质心的方法，画出它随着音乐波形和STFT频谱的变化，可见在5.5秒左右羽管键琴开始演奏时，数值跟之前的钢琴音频相比有明显升高。代码如下：<br></p><pre><ol><li><p><span><code><span>audio, sr = librosa.load(</span><span>'attachment/mir02-centroidaudio.wav'</span><span>)</span></code></span></p></li><li><p><span><code><span>D = librosa.stft(audio, n_fft=</span><span>2048</span><span>, hop_length=</span><span>512</span><span>)</span></code></span></p></li><li><p><span><code><span>magnitude, phase = librosa.magphase(D)</span></code></span></p></li><li><p><span><code><span>cent = librosa.feature.spectral_centroid(y=audio, sr=sr)</span></code></span></p></li><li><p><span><code></code></span></p></li><li><p><span><code><span>plt.figure(figsize=(</span><span>15</span><span>,</span><span>10</span><span>))</span></code></span></p></li><li><p><span><code><span># 画出音频数据在时域上的波形图</span></code></span></p></li><li><p><span><code><span>ax1 = plt.subplot(</span><span>2</span><span>,</span><span>1</span><span>,</span><span>1</span><span>)</span></code></span></p></li><li><p><span><code><span>librosa.display.waveplot(audio, sr, alpha=</span><span>0.8</span><span>)</span></code></span></p></li><li><p><span><code><span>plt.title(</span><span>'audio data'</span><span>)</span></code></span></p></li><li><p><span><code><span># 画出STFT后的功率谱（以dB为单位）以及频谱质心随时间的变化</span></code></span></p></li><li><p><span><code><span>ax2 = plt.subplot(</span><span>2</span><span>,</span><span>1</span><span>,</span><span>2</span><span>, sharex=ax1)</span></code></span></p></li><li><p><span><code><span>librosa.display.specshow(librosa.amplitude_to_db(magnitude, </span><span>ref</span><span>=np.max), sr=sr, y_axis=</span><span>'linear'</span><span>, x_axis=</span><span>'time'</span><span>)</span></code></span></p></li><li><p><span><code><span>cent_times = librosa.frames_to_time(np.arange(len(cent[</span><span>0</span><span>])), sr=sr, hop_length=</span><span>512</span><span>)</span></code></span></p></li><li><p><span><code><span>plt.plot(cent_times, cent[</span><span>0</span><span>], label=</span><span>'Spectral Centroid'</span><span>, lw=</span><span>4</span><span>, color=</span><span>'orange'</span><span>)</span></code></span></p></li><li><p><span><code><span>plt.legend()</span></code></span></p></li><li><p><span><code><span>plt.title(</span><span>'STFT spectrogram &amp; Spectral Centroid'</span><span>)</span></code></span></p></li></ol></pre><p><img src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJXmNvSXgEbnw32vmks2Wov6ibQjXWlO6HAM9VuwZwRxBXiavlrg8bWedma0Nnq2qaMAv9ZsTcJ9LQjw/640"></p><hr><h3>『频谱差分幅度』</h3><p>频谱差分幅度(spectral flux)可以表示音频频谱中的功率变化的有多快，因此在公式上计算的是相邻两帧之间谱的变化量。但在具体计算这个“变化量”时，目前有几种经典的算法，可以主要参考以下两篇论文：</p><p><span>☞ Dixon, Simon. "Onset detection revisited." Proceedings of the 9th International Conference on Digital Audio Effects. pp.133–137. 2006. <a href="https://www.eecs.qmul.ac.uk/~simond/pub/2006/dafx.pdf" target="_blank" rel="noopener">https://www.eecs.qmul.ac.uk/~simond/pub/2006/dafx.pdf</a>
+☞ Böck, Sebastian, and Gerhard Widmer. "Maximum filter vibrato suppression for onset detection." Proceedings of the 16th International Conference on Digital Audio Effects. 2013. <a href="http://dafx13.nuim.ie/papers/09.dafx2013" target="_blank" rel="noopener">http://dafx13.nuim.ie/papers/09.dafx2013</a><span>submission</span>12.pdf</span></p><p>之所以能用频谱差分幅度作为检测音符弹奏时刻(onset)的方法，就是利用新的音符在弹奏时带来的频谱能量上的突变，这种突变也许在时域特征RMS能量上不那么明显，因此凸显出频谱差分幅度的优越性。然而它的弱点在于如何抵制颤音技巧带来的影响，这也是为什么上方第二个文献会提出的一种super flux的方法。</p><p>✎ 我们继续用上方音频画出它的频谱差分幅度随时间的变化：</p><pre><ol><li><p><span><code><span>spectral_flux = librosa.onset.onset_strength(y=audio, sr=sr, hop_length=</span><span>512</span><span>)</span></code></span></p></li><li><p><span><code><span>spectral_flux_times = librosa.frames_to_time(np.arange(len(spectral_flux)), sr=sr, hop_length=</span><span>512</span><span>)</span></code></span></p></li><li><p><span><code></code></span></p></li><li><p><span><code><span>onset_times = librosa.onset.onset_detect(onset_envelope=spectral_flux, sr=sr, hop_length=</span><span>512</span><span>, units=</span><span>'time'</span><span>)</span></code></span></p></li><li><p><span><code></code></span></p></li><li><p><span><code><span>plt.figure(figsize=(</span><span>12</span><span>,</span><span>10</span><span>))</span></code></span></p></li><li><p><span><code><span># 画出STFT功率谱（以dB为单位）</span></code></span></p></li><li><p><span><code><span>ax1 = plt.subplot(</span><span>2</span><span>,</span><span>1</span><span>,</span><span>1</span><span>)</span></code></span></p></li><li><p><span><code><span>librosa.display.specshow(librosa.amplitude_to_db(magnitude, </span><span>ref</span><span>=np.max), sr=sr, y_axis=</span><span>'linear'</span><span>, x_axis=</span><span>'time'</span><span>)</span></code></span></p></li><li><p><span><code><span>plt.xlim([</span><span>0</span><span>, </span><span>11</span><span>])</span></code></span></p></li><li><p><span><code><span>plt.title(</span><span>'STFT spectrogram '</span><span>)</span></code></span></p></li><li><p><span><code><span># 画出频谱差分幅度，以及基于其被检测出的onset</span></code></span></p></li><li><p><span><code><span>ax2 = plt.subplot(</span><span>2</span><span>,</span><span>1</span><span>,</span><span>2</span><span>, sharex=ax1)</span></code></span></p></li><li><p><span><code><span>plt.plot(spectral_flux_times, spectral_flux, lw=</span><span>2</span><span>, alpha=</span><span>0.75</span><span>, label=</span><span>'Spectral flux'</span><span>)</span></code></span></p></li><li><p><span><code><span>plt.vlines(onset_times, </span><span>0</span><span>, spectral_flux.max(), label=</span><span>'Onsets'</span><span>, lw=</span><span>3</span><span>, color=</span><span>'orange'</span><span>)</span></code></span></p></li><li><p><span><code><span>plt.xlim([</span><span>0</span><span>, </span><span>11</span><span>])</span></code></span></p></li><li><p><span><code><span>plt.legend()</span></code></span></p></li><li><p><span><code><span>plt.title(</span><span>'Spectral Flux &amp; Detected Onset'</span><span>)</span></code></span></p></li></ol></pre><p><img src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJXmNvSXgEbnw32vmks2Wov6TWXFts9EZrFKWLwiaO80fZaDYHibRCnb1z5Xe2vRnUgJNkHicqaVntqhw/640"></p><p>✎ 上方在计算出spectral flux之后，可利用峰值检测(peak picking)的方法得出onset到底发生在那个时刻。<br></p><hr><h3>『梅尔倒谱系数MFCC』</h3><p>梅尔倒谱系数（Mel Frequency Cepstral Coefficients，简称MFCC）在80年代被Davis和Mermelstein提出之后，就在语音识别/话者识别的任务中挑大梁挑了好多年。相比于用 <code><span>F(频点数量)x T(帧数)</span></code>表示一段音频，尤其是 <code><span>F</span></code>可能高达成千上万，使用MFCC就能有效降维到 <code><span>MFCCsx T</span></code>。这里的“有效”就在于MFCC能用几个系数表示每个帧内最有用的信息，而系数得出的过程又和人耳对声音频率以及响度的认知息息相关，可以说是一个非常美丽的算法了。尽量略过数学计算，可以将计算过程表示为以下6步骤：</p><p>第1步：参照STFT的第1步，我们需要将音频分成连续的一帧帧；</p><p>第2步：在每一帧里用DFT（或者其加速版-FFT）得出功率谱；</p><p>第3步：在每一帧里的功率谱都加上Mel尺度的三角形滤波器组（就像下图filterbank一样），在每个滤波器覆盖的范围下计算出其涵盖的能量值；</p><p><img src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJXmNvSXgEbnw32vmks2Wov6wU4ANdAfITIlbayX1wxIc2NDe0nF3jFIhnP8sPjAia4vPzlgBKxQlJg/640"></p><p>那么问题来了，为什么要加Mel尺度而非线性的？因为人耳本身的感知能力有限，在低频区域也许能分清50Hz和60Hz的区别，但同样差10个Hz,分清1050与1060Hz就没那么容易了，再往上走，4000Hz变成5000Hz，也许你觉得就高了几十个Hz而已。总而言之，人耳在感受客观上线性递增的频率时，其实是主观理解成 <code><span>m_freq=2595x log10(1+f/700)</span></code>这样的。因此如上方小图(a)中，高的频段里就没必要还用那么“窄”的滤波器去提取信息了，反正窄的宽的你也听不出来，不如用宽点的滤波器来节省一些计算。<br></p><p>第4步：对每一帧里的每个滤波器下得出的能量，取！对！数！为什么？因为人耳不仅对频率变得越来越高没那么敏感，音量变得越来越大也感受没那么大，人家客观能量也许提高了足足八倍，你才在主观上能大致感受到“诶这个音量好像提高了一倍哦？”</p><p>第5步：最后，对每一帧下的Mel频谱对数能量谱做离散余弦变换（DCT）得到表示该谱包络形状的系数们，只保留前几个主要的系数即是我们需要的MFCC了！</p><p>✎ 在代码部分依然可以直接用librosa提取，还是用之前的音频，在其每一帧下提取20个MFCC的话：</p><pre><ol><li><p><span><code><span>mfccs = librosa.feature.mfcc(y=audio, sr=sr, n_mfcc=</span><span>20</span><span>)</span></code></span></p></li><li><p><span><code><span>plt.figure(figsize=(</span><span>10</span><span>, </span><span>4</span><span>))</span></code></span></p></li><li><p><span><code><span>librosa.display.specshow(mfccs, x_axis=</span><span>'time'</span><span>)</span></code></span></p></li><li><p><span><code><span>plt.colorbar()</span></code></span></p></li><li><p><span><code><span>plt.title(</span><span>'MFCC'</span><span>)</span></code></span></p></li></ol></pre><p><img src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJXmNvSXgEbnw32vmks2Wov6wT7AmtibaM77JSRYDyCricWTnqvJ7MIGXPOr0RBpjIDQXDMDjEogibeIg/640"></p><p>✎ 肉眼可见0-5.5秒内的钢琴和5.5秒之后的羽管键琴在MFCC上的区别，比如上图最下方第二排对应的数值中，钢琴就比羽管键琴更“红”。抓住MFCC中的区别，既然能实现话者识别，那么也能做出乐器识别。<br></p><p><span>☞ 更多MFCC计算细节可参照CMU语音课的幻灯片<a href="http://www.speech.cs.cmu.edu/15-492/slides/03_mfcc.pdf" target="_blank" rel="noopener">http://www.speech.cs.cmu.edu/15-492/slides/03_mfcc.pdf</a></span></p><hr><p>以上提出的频域特征一般不随音乐的音高发生改变，如果你想识别出一段音频中的旋律是怎样的，请期待下节「MIR-02_4」乐音特征(harmonic feature)!</p><p><span><b>上文回顾：</b></span></p><p><span><b>- <a href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483704&amp;idx=1&amp;sn=e6705ea9535890e16f87a9b1c7956226&amp;chksm=fe0d9f97c97a16815ac0df35d02ef2d66eb14644589f05ab8aec8f407c2c9d31ced863f6240f&amp;scene=21#wechat_redirect" target="_blank">「MIR-02_1」音频特征小全之概览</a></b></span></p><p><span><b>- <a href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483733&amp;idx=1&amp;sn=e880a75645ad92e49fe9b80f5b5d5b67&amp;chksm=fe0d9ffac97a16ecc093ee5461812d9010134755a5642244200054cad693e99749fae18cc25d&amp;scene=21#wechat_redirect" target="_blank">「MIR-02_2」音频特征小全之时域特征</a></b></span></p>
+    </div>
+  </article>
+</body>
+</html>

--- a/articles/audio-feature-musical.html
+++ b/articles/audio-feature-musical.html
@@ -1,0 +1,408 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>「MIR-02_4」音频特征小全之乐音特征 - 无痛入门音乐科技</title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「MIR-02_4」音频特征小全之乐音特征</h1>
+      <div class="meta">无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            乐音特征(harmonic
+            feature)简单概括就是许多方便检测音高/旋律/和弦的特征。
+          </p>
+        </blockquote>
+        <p>
+          <span
+            ><strong>♬ 本文为MIR音乐信息检索系列的第2.4篇文章 ♬</strong></span
+          >
+        </p>
+        <p>
+          <span
+            ><strong
+              >♬
+              该文与2.1概览+2.2时域特征+2.3频域特征及后续2.5特征提取工具共同组成音频特征小全
+              ♬</strong
+            ></span
+          >
+        </p>
+        <p><span>本文将大致讲解以下问题中涉及到的乐音特征：</span></p>
+        <ul>
+          <li>
+            <p><span>什么是音高？它与基音和泛音有什么联系？</span></p>
+          </li>
+          <li>
+            <p><span>如何识别一首歌的音高变化？</span></p>
+          </li>
+          <li>
+            <p><span>如何识别一首歌的和弦进行？</span></p>
+          </li>
+        </ul>
+        <hr />
+        <h3>『音高』</h3>
+        <p>
+          音高(pitch)可以指我们“感觉上”的声音的高低。大多数情况下，音高由乐器发出的基本频率决定（简称为基频fundamental
+          frequency即F0，单位为赫兹Hz），越高的音高对应的F0数值越大。但是乐器发出的每个音不仅仅包括基频正弦波的“基音”，还同时由许多频率较高的正弦波也就是“泛音”组成。基音与泛音这些不同频率的正弦波的叠加才是我们真正听到的音。
+        </p>
+        <p>
+          来，我们直接给钢琴中央C的单音音频做个离散傅里叶变换，得到下方的频谱图，红色点对应的横轴频率值为262.4Hz即F0，黑色点点们则对应了泛音。
+        </p>
+        <p>
+          <img
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJWYrard3icJRZtqMsOjA4tZD4CT22HNaibdicF8pHt9HUfBQnRM6PXk5icnkMR0ZzDPTDC71ORIG1wuibQ/640"
+          />
+        </p>
+        <p>
+          理想情况下，泛音和基音之间的频率值应该是整数倍的关系，由于钢琴本身的物理特性，第n个泛音和基音之间关系其实是
+        </p>
+        <p>
+          <img
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJWYrard3icJRZtqMsOjA4tZDJlzibDLdrzODI84GuibNOLDNdQicApNKcVRhibEfJdmlTf6sib3OrdaOkNw/640"
+          />
+        </p>
+        <p>其中B称为不谐和系数，且钢琴88个音中每个音的B值都不同。</p>
+        <p>
+          ✎
+          给定钢琴每个音的音频，如何从各个音频中估计每个音的F0与B，可参考文献<span
+            >F. Rigaud, B. David, and L. Daudet, “A parametric model and
+            estimation techniques for the inharmonicity and tuning of the
+            piano”, The Journal of the Acoustical Society of America, vol. 133,
+            no. 5, pp. 3017–3118, 2013.</span
+          >
+        </p>
+        <p>
+          ☞ 上方文献的python2代码实现可参见我的GitHub
+          <span
+            ><a
+              href="https://github.com/beiciliang/estimate-f0-inharmonicity"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/beiciliang/estimate-f0-inharmonicity</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞ Matlab代码可参见Tian Cheng的
+          <span
+            ><a
+              href="https://code.soundsoftware.ac.uk/projects/inharmonicityestimation"
+              target="_blank"
+              rel="noopener"
+              >https://code.soundsoftware.ac.uk/projects/inharmonicityestimation</a
+            ></span
+          >
+        </p>
+        <hr />
+        <h3>『音高识别』</h3>
+        <p>
+          在MIR学界中，一大主流方向就是识别音频中每一帧内的音高或基频(pitch/F0
+          estimation)。最简单的情况是音频中只有一个声源，且该声源只发出单旋律，比如音频中只有一个人在唱歌且这个人还不会蒙古呼麦。中间级别的情况就是一个声源可以同时发出好几个音，所以音频是复音音乐，比如钢琴音乐的“扒谱”(piano
+          transcription)。最复杂的情况就是大型交响乐，多个声源的复音音乐。
+        </p>
+        <p>
+          和音高检测相关的MIR任务还有旋律识别(melody
+          estimation)、人声音高识别(vocal-f0
+          estimation)等等。为了提高识别的准确度，还有许多“旁系”任务，比如声源分离(source
+          separation)和歌唱声音事件检测(singing voice detection)。
+        </p>
+        <p>
+          基于以上任务开发的算法大多被应用于哼唱检索上(query by
+          humming)，用户不跑调地哼唱一段“321~321~3231365~”的旋律后，系统通过计算该旋律和曲库里歌曲们旋律的相似度，匹配到“我爱你~爱着你~好像老鼠爱大米~”这个音频片段，最后返回“老鼠爱大米”作为检索结果（好像暴露了我的年龄……）。注意，大多数APP中“听歌识曲”可不是用旋律做匹配，而是用一些可以表征不同歌曲的声纹做匹配和检索（好比每个人有指纹，每首歌曲也有自己的声纹，声纹的建立更多依赖于其时频谱上的能量分布，具体原理我们以后科普哈）。
+        </p>
+        <p>
+          那么到底如何识别音高？这里主要说流程，具体资料与代码放在这部分的最后。
+        </p>
+        <p>
+          1.首先，还是如前文提过无数次的“将音频信号从时域变换为频域”，得到随着时间变化的频谱，如下方左图。
+        </p>
+        <p>
+          2.利用基于不同识别方法的模型与优化，得到强调乐音部分并抑制其他干扰项的“突显”时频谱(salience
+          representation)，如下方右图。
+        </p>
+        <p>
+          <img
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJWYrard3icJRZtqMsOjA4tZDkC77x22ol0cjW8Cwe1A50fXE9XrohZJnEsibfiaHtc9gsO0YTh916I3g/640"
+          />
+        </p>
+        <p>
+          3.最后从salience中解析出每一帧内有哪些音高，得到类似下图的结果（黑色为标准答案，红色为算法估计结果）。
+        </p>
+        <p>
+          <img
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJWYrard3icJRZtqMsOjA4tZDVKfpIYJOqPZ2ibnEZarHLZJnPHtzQnehXfCQAUyyZDQxnI9q6iaEOsYQ/640"
+          />
+        </p>
+        <p>
+          目前第2步的主流方法是神经网络，在这之前比较火的是非负矩阵分解即NMF，并较为成功的应用在钢琴转录中(我的GitHub里有一款python实现<span
+            ><a
+              href="https://github.com/beiciliang/modelAttackDecay-for-piano-transcription"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/beiciliang/modelAttackDecay-for-piano-transcription</a
+            ></span
+          >，但关于钢琴转录目前最成功的是Google Magenta做出的Onsets and Frames:
+          Dual-Objective Piano
+          Transcription)。第3步中可以衍生出针对于歌曲主旋律的识别。
+        </p>
+        <p>对详细的检测方法感兴趣的读者，推荐搜索以下前辈们的工作：</p>
+        <p>☞ “突显”时频谱的优化和F0识别：Rachel Bittner</p>
+        <p>☞ 针对于钢琴的F0识别：Emmanouil Benetos, Zhiyao Duan</p>
+        <p>☞ 旋律识别：Justin Salamon, Juanjo Bosch</p>
+        <p>
+          另外在之前2.1时域特征中，简单提到了单音识别，目前state-of-the-art是CREPE:
+          A Convolutional REpresentation for Pitch Estimation
+          <span
+            >(<a
+              href="https://github.com/marl/crepe)"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/marl/crepe)</a
+            ></span
+          >，在此之前应用比较广泛的纯信号处理方法为pYIN: Probabilistic YIN
+          <span
+            >(<a
+              href="https://code.soundsoftware.ac.uk/projects/pyin)&nbsp;"
+              target="_blank"
+              rel="noopener"
+              >https://code.soundsoftware.ac.uk/projects/pyin)&nbsp;</a
+            ></span
+          >(龚嵘博士的GitHub里有python版本即pypYIN
+          <span
+            >(<a
+              href="https://github.com/ronggong/pypYIN)"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/ronggong/pypYIN)</a
+            ></span
+          >).
+        </p>
+        <hr />
+        <h3>『和弦识别』</h3>
+        <p>
+          如果说把音频中每个音高识别出来过于精细，也许只识别出和弦(chord)就能满足大多数吉他爱好者了！音高识别依赖于salience
+          representation，而早年间对和弦的识别则依赖于色度图谱(chromagram)，这种图谱与一般时频谱的主要区别在于，它的纵轴不是频率的递增，而是12个音级(中央C和高音C这两个音差了八度，但他们的音级都是C，根据十二平均律我们有12个音级)。把时频谱上同一时间、同一音级、不同八度的音符的能量叠加该音级上，即得到该时间的色度图谱。如果此刻C、E、G三个音级上的能量较高，我们可以推测Cmaj和弦在演奏。
+        </p>
+        <p>
+          以色度图谱为起始点，Matthias Mauch在我们C4DM读博士期间提出的NNLS
+          Chroma可以说是对和弦检测一个重要的提升，并一直作为MIREX和弦检测任务中类似baseline的存在，他也是Queen
+          and Zweieck dataset的作者，并助攻Christopher Harte的Beatles
+          dataset（话说MIREX里的JayChou29 dataset是Junqi Deng学长的功劳哦）。
+        </p>
+        <p>
+          但目前的主流方法……嗯对，又是神经网络，主要提升的点是对“非常见”和弦的检测力度。对详细检测过程感兴趣的话，可以搜索前文提到的学者，以及
+          Sebastian Böck, Johan Pauwels等等。
+        </p>
+        <hr />
+        <p>
+          说实话，还有许多大大小小的数学细节和技术原理还没有讲到，下一节2.5也是“音频特征小全系列”最后一节将介绍一些常用的特征提取工具，之后我们再就着具体案例具体分析。
+        </p>
+        <p>
+          另外遥祝第6届中国声音与音乐技术会议圆满成功呀！下一届的时候我就人在国内可以参加了:)
+        </p>
+        <p>
+          <strong><span>上文回顾：</span></strong>
+        </p>
+        <ul>
+          <li>
+            <p>
+              <a
+                href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483704&amp;idx=1&amp;sn=e6705ea9535890e16f87a9b1c7956226&amp;chksm=fe0d9f97c97a16815ac0df35d02ef2d66eb14644589f05ab8aec8f407c2c9d31ced863f6240f&amp;scene=21#wechat_redirect"
+                target="_blank"
+                ><span>「MIR-02_1」音频特征小全之概览</span></a
+              ><br />
+            </p>
+          </li>
+          <li>
+            <p>
+              <a
+                href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483733&amp;idx=1&amp;sn=e880a75645ad92e49fe9b80f5b5d5b67&amp;chksm=fe0d9ffac97a16ecc093ee5461812d9010134755a5642244200054cad693e99749fae18cc25d&amp;scene=21#wechat_redirect"
+                target="_blank"
+                ><span>「MIR-02_2」音频特征小全之时域特征</span></a
+              ><br />
+            </p>
+          </li>
+          <li>
+            <p>
+              <a
+                href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483747&amp;idx=1&amp;sn=3651815c811239e4d68fd6901132c87b&amp;chksm=fe0d9fccc97a16da88eccd6c5aaf7f69d0fa00be2b785016779a7b03be29a244c4e72ffe0175&amp;scene=21#wechat_redirect"
+                target="_blank"
+                ><span>「MIR-02_3」音频特征小全之频域特征</span></a
+              ><br />
+            </p>
+          </li>
+        </ul>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/audio-feature-overview.html
+++ b/articles/audio-feature-overview.html
@@ -1,0 +1,372 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>「MIR-02_1」音频特征小全之概览 - 无痛入门音乐科技</title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「MIR-02_1」音频特征小全之概览</h1>
+      <div class="meta">无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            在深度学习成为给音频打上标签的小能手之前，设计各种各样的音频特征（audio
+            feature）才是音频分类或识别任务的领头军，其中充满了声学、数学建模和信号处理等技术的灵活运用，也是领会音乐技术的必修知识。
+          </p>
+        </blockquote>
+        <p>
+          <span
+            ><strong>♬ 本文为MIR音乐信息检索系列的第2.1篇文章 ♬</strong></span
+          >
+        </p>
+        <p>
+          <span
+            ><strong
+              >♬ 该文作为概览将与后续2.X文章共同组成音频特征小全 ♬</strong
+            ></span
+          >
+        </p>
+        <p><span>概览内容包括：</span></p>
+        <ul>
+          <li>
+            <p><span>音频特征可以从几种角度去理解？</span></p>
+          </li>
+          <li>
+            <p><span>根据特征的来源可以将其分为几类？</span></p>
+          </li>
+          <li>
+            <p><span>提取特征之前有哪些预处理工作？</span></p>
+          </li>
+        </ul>
+        <hr />
+        <h3>『理解音频特征』</h3>
+        <p>
+          大多数音频特征起源于语音识别领域，用于理解录音中人们说了哪些话，直到九十年代末它们才被应用到音乐信息检索的任务中，逐渐也就有了更多针对于音乐音频的特征被发明出来。
+        </p>
+        <p>
+          <span>☞ 大概是最久远的MIR论文之一：</span
+          ><span
+            >Foote, Jonathan T. "Content-based retrieval of music and audio."
+            Multimedia Storage and Archiving Systems II. Vol. 3229.
+            International Society for Optics and Photonics, 1997.</span
+          >
+        </p>
+        <p>
+          我们的目的并不在于如何把所有特征细致地分类，而是指明可用哪些角度理解或区分开各种特征。大致上有以下四种角度：
+        </p>
+        <p>
+          ✎
+          特征的动与稳：一个特征在每段时间内都可用数值表示，随着时间轴的移动，数值大小会不断变换，那么连续多段时间内多个数值的均值/方差等就代表了该特征的动态性，但这个数值本身的物理意义是不变的，这就构成了特征“稳”的部分。
+        </p>
+        <p>
+          ✎
+          特征可覆盖的时间长短：上面提到的每段时间中的段字，即可以是音频信号加窗后得到的一帧帧，也可以是前奏/主歌/副歌等时间跨度略长的片段，因此得到的特征可以是瞬态的(instantaneous)或全局的(global)。
+        </p>
+        <p>
+          ✎
+          特征的抽象程度：越抽象，人们就越难理解，那么就对应了越底层的特征，底层特征经过处理可以变成中层的特征，比如音高、音符起始点等等，抽象程度大致等于理解乐谱里常见的音乐元素，最高层的特征则被赋予了更多语义，比如音乐的体裁等等。
+        </p>
+        <p>✎ 特征的提取过程：在这种角度下，还能细分成以下四种过程</p>
+        <ul>
+          <li>
+            <p>
+              <span
+                >直接在音频波形上提取的特征，比如过零率(zero-crossing
+                rate)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >将音频进行DFT/FFT等变换后提取的特征，比如谱质心(spectral
+                centroid)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >需通过模型才能得到的特征，比如通过声源分离得到乐音相关的特征</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >受人耳听觉认知的启发，经过特定比例(mel或bark)过滤后得到的特征</span
+              >
+            </p>
+          </li>
+        </ul>
+        <hr />
+        <h3>『音频特征的类别』</h3>
+        <p>
+          <img
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJVcf6KcKuAw9yeqWV1icsH1M4lR15ozIHGsVAk4s5dq1st0Yoc4C2UkgX9KvsXS2grmkiaXJY1owLHQ/640"
+          />
+        </p>
+        <p>
+          如果被上述角度绕得云里雾里的，可以参考上方图片里的各处流程中得到的不同特征，由此可将特征分为以下几大常用类别：<br />
+        </p>
+        <p>
+          ✎ 时域特征(temporal
+          feature)：可从音频波形直接观察到的能量包络得出有关ADSR的特征，也可在某一帧下计算自相关系数和过零率等特征。
+        </p>
+        <p>
+          ✎ 频域特征(spectral
+          feature)：此类特征更更多，随意举例包括质心(centroid)、偏态(skewness)、峰态(kurtosis)，还有大名鼎鼎的MFCC等等。
+        </p>
+        <p>
+          ✎ 乐音特征(harmonic feature)：对输入经过sinusoidal harmonic
+          modelling后得出的特征，比如乐音与噪音的比值等等。
+        </p>
+        <p>
+          ✎ 感知特征(spectral
+          feature)：符合人耳听觉认知的特征，如响度(loudness)。
+        </p>
+        <p>
+          ✎ 能量特征(energy
+          feature)：主要指各种与能量相关的特征，如乐音能量、噪音能量，或计算每帧下均方根的能量(RMS
+          energy)等等。
+        </p>
+        <p>
+          <strong
+            >在公众号接下来的2.X文章中，就会重点讲解每一类下常见特征的计算过程及其在MIR上的应用。</strong
+          >
+        </p>
+        <hr />
+        <h3>『提取特征前的预处理』</h3>
+        <p>
+          虽然名字上叫预处理，但对于许多特征来说，其实是在提取前必须要做的步骤。
+        </p>
+        <p>
+          比如上段提到的能量包络，可以通过计算均方根能量得到。我们仍用MIR-01博文中的音频为例，代码及图像如下：
+        </p>
+        <pre><ol><li><p><span><code><span># 加载音频</span></code></span></p></li><li><p><span><code><span>audio_data, sr = librosa.load(</span><span>'attachment/mir01-music-example.wav'</span><span>, sr=</span><span>None</span><span>)</span></code></span></p></li><li><p><span><code><span># 调用librosa中的rmse直接对音频每个长度为2048的帧进行计算得到均方根能量</span></code></span></p></li><li><p><span><code><span>rmse = librosa.feature.rmse(audio_data, frame_length=</span><span>2048</span><span>, hop_length=</span><span>512</span><span>)</span></code></span></p></li><li><p><span><code><span># 画出音频波形及均方根能量随时间的变化</span></code></span></p></li><li><p><span><code><span>plt.figure(figsize=(</span><span>10</span><span>,</span><span>5</span><span>))</span></code></span></p></li><li><p><span><code><span>librosa.display.waveplot(audio_data, sr, alpha=</span><span>0.8</span><span>)</span></code></span></p></li><li><p><span><code><span>times = librosa.frames_to_time(np.arange(len(rmse.T)), sr=sr, hop_length=</span><span>512</span><span>)</span></code></span></p></li><li><p><span><code><span>plt.plot(times, rmse.T, label=</span><span>'RMS Energy'</span><span>)</span></code></span></p></li><li><p><span><code><span>plt.legend(loc=</span><span>'best'</span><span>)</span></code></span></p></li></ol></pre>
+        <p>
+          <img
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJVcf6KcKuAw9yeqWV1icsH1MnJzldPnuRO9ZuIqWdxlUGgWELQ2SiaSIefSILCMQaib0ic0QojIeyZczA/640"
+          />
+        </p>
+        <p>
+          另外一大常用的预处理就是将音频信号从时域变换为频域，主要用到的时频谱在MIR-01文章的最后一部分已有介绍过，这里主要提示下在变换过程中，容易混淆的一些概念与术语。<br />
+        </p>
+        <p>
+          经过STFT得到的振幅谱其实是一个二维矩阵 <code><span>D</span></code
+          >，其中一维沿着时间，另一维沿着频率。首先“时间”并不用日常生活中的分秒来表示，画图显示频谱时会用分秒，但数据本身的时间轴是以“帧”即frame为单位，每一帧代表多少秒，是由原始音频的采样率
+          <code><span>sr</span></code
+          >，和对信号加窗后两窗之间的距离 <code><span>hop_length</span></code
+          >决定，因此一帧等于 <code><span>hop_length/sr</span></code
+          >所得的秒数。
+        </p>
+        <p>
+          每一帧下的频谱，频率的分辨率由 <code><span>sr</span></code
+          >以及DFT或FFT的窗长 <code><span>n_fft</span></code
+          >决定，因此每一个频点frequency bin覆盖了
+          <code><span>sr/n_fft</span></code
+          >范围的频率。
+        </p>
+        <p>
+          在指定frame（假设为 <code><span>t</span></code
+          >）与frequency bin（假设为 <code><span>f</span></code
+          >）对应的矩阵位置上即 <code><span>D[f,t]</span></code
+          >，由于经过傅里叶变换的原因，其值是一个复数，由此可得该点振幅magnitude为
+          <code><span>numpy.abs(D[f,t])</span></code
+          >，而相位则为 <code><span>numpy.angle(D[f,t])</span></code
+          >。将振幅谱D上的所有值做平方即 <code><span>D**2</span></code
+          >，我们就得到了功率谱。无论是振幅谱(amplitude
+          spectrogram)还是功率谱(power
+          spectrogram)，都可以对矩阵上的值取对数转换为以dB为单位的值，此时可称频谱为对数谱log-spectrogram。
+        </p>
+        <p>
+          注意不要混淆的是，沿着频率轴也经常进行对数操作(log-frequency
+          scale)以得到梅尔频谱，这样得到的梅尔频率标度拟合了人耳对频率的感知度。此外，Bark
+          scale是更加贴切人耳对频率感知的标度，但它对频率并不采取对数操作。
+        </p>
+        <p>
+          其他预处理涉及到滤波和专用模型的运用，博主还是后续文章中就着具体例子具体介绍吧_(:3
+          」∠ )_
+        </p>
+        <hr />
+        <p>
+          <span>上文回顾：</span
+          ><a
+            href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483684&amp;idx=1&amp;sn=d3f3746a6837f7d12044d1931cfd4ead&amp;chksm=fe0d9f8bc97a169dbfcb80443e8da87d8e35ae643bae76841060442d8f88a4f292cda594afa5&amp;scene=21#wechat_redirect"
+            target="_blank"
+            ><span>「MIR-01」要把音乐画出来，总共分几步？</span></a
+          >
+        </p>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/audio-feature-time.html
+++ b/articles/audio-feature-time.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>「MIR-02_2」音频特征小全之时域特征 - 无痛入门音乐科技</title>
+  <style>
+    :root {
+      --bg: #f5f5f7;
+      --card-bg: #ffffff;
+      --text: #1d1d1f;
+      --text-secondary: #6e6e73;
+      --accent: #5856d6;
+      --border: #d2d2d7;
+      --code-bg: #f0f0f3;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0d0d12;
+        --card-bg: #1c1c24;
+        --text: #f0f0f5;
+        --text-secondary: #8e8e93;
+        --accent: #7b79ff;
+        --border: #2c2c34;
+        --code-bg: #15151d;
+      }
+    }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", Roboto, "Noto Sans SC", sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.8;
+    }
+    .header {
+      background: linear-gradient(135deg, #0f0c29 0%, #302b63 50%, #24243e 100%);
+      padding: 2rem 1.5rem;
+      text-align: center;
+    }
+    .header a {
+      color: rgba(255,255,255,0.7);
+      text-decoration: none;
+      font-size: 0.9rem;
+    }
+    .header a:hover { color: #fff; }
+    article {
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem 4rem;
+    }
+    article h1 {
+      font-size: 1.8rem;
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+      line-height: 1.3;
+    }
+    .meta {
+      color: var(--text-secondary);
+      font-size: 0.85rem;
+      margin-bottom: 2rem;
+      padding-bottom: 1rem;
+      border-bottom: 1px solid var(--border);
+    }
+    .content { font-size: 1rem; }
+    .content p,
+      .content section { margin-bottom: 1rem; }
+    .content img {
+      max-width: 100%;
+      height: auto;
+      border-radius: 8px;
+      margin: 1rem 0;
+    }
+    .content h2, .content h3 {
+      text-align: center;
+      margin: 1.5rem 0 0.8rem;
+      font-weight: 600;
+    }
+    .content blockquote {
+      border-left: 3px solid var(--accent);
+      padding-left: 1rem;
+      color: var(--text-secondary);
+      margin: 1rem 0;
+    }
+    .content a { color: var(--accent); }
+    .content hr {
+      border: none;
+      border-top: 1px solid var(--border);
+      margin: 1.5rem 0;
+    }
+    .content ul, .content ol {
+      padding-left: 1.5rem;
+      margin-bottom: 1rem;
+    }
+    .content li { margin-bottom: 0.3rem; }
+    .content table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1rem 0;
+    }
+    .content th, .content td {
+      border: 1px solid var(--border);
+      padding: 0.5rem;
+      text-align: left;
+    }
+    .content pre, .content code {
+      font-family: "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+      font-size: 0.85em;
+    }
+    .content code {
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 0.15rem 0.4rem;
+    }
+    .content pre {
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1rem 1.2rem;
+      overflow-x: auto;
+      margin: 1rem 0;
+      line-height: 1.5;
+    }
+    .content pre code {
+      background: none;
+      border: none;
+      padding: 0;
+      font-size: inherit;
+      display: block;
+    }
+    .content pre ol {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+    .content pre li {
+      margin: 0;
+      padding: 0;
+    }
+    .content pre p {
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+  </div>
+  <article>
+    <h1>「MIR-02_2」音频特征小全之时域特征</h1>
+    <div class="meta">无痛入门音乐科技</div>
+    <div class="content">
+      <blockquote><p>时域特征(temporal feature)就好比描述音频波形的指标，可以说没有比它更直观的特征了。文章中的代码部分若在手机端无法正确显示，请移步网页端。</p></blockquote><p><span><strong>♬ 本文为MIR音乐信息检索系列的第2.2篇文章 ♬</strong></span></p><p><span><strong>♬ 该文与上篇2.1概览及后续2.X文章共同组成音频特征小全 ♬</strong></span></p><p><span>本文将主要讲解以下时域特征及其简单应用：</span></p><ul><li><p><span>如何从ADSR包络中观察不同乐器声音的生老停死？</span></p></li><li><p><span>如何用过零率找到动次打次中“打”的地方？</span></p></li><li><p><span>如何用自相关算法识别单音音高？</span></p></li></ul><hr><h3>『ADSR包络』</h3><p>前文2.1概览的最后，我们计算了一帧帧下均方根能量的值，从而得出音频中能量随时间变化的曲线。这个能量曲线就是我们要说的包络(envelope)，每个乐器发出一个单音得到的包络都有所不同，而这些“不同”可以反映在包络的ADSR四个区域里，分别为起音(attack)、衰减(decay)、延音(sustain)和释音(release)。</p><p><img src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJW5ibULYpq3DukKPbQrgxPlLicKVol22ibNDXYeKVn2DUic2Km1QeDoHHEq1CMK1gfsqraYfleGnN7aqw/640"></p><p>✎ 一般击弦乐器和打击类乐器的起音都很短，起音之后也不会再有其他机械能的输入因此也不会有延音的阶段，而管弦乐器的延音部分就会很长。下图简单描画了一些乐器的包络。</p><p><img src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJW5ibULYpq3DukKPbQrgxPlLN7OVa4e4mtpicG66yV0bf6IBgpfu0rHZ7Yyw8zgicibA1fnJsWoY7ME4A/640"></p><p>✎ 包络的差异是帮助我们理解“不同乐器有不同音色”的助手之一，但其他助手们主要集中在频域特征里。</p><hr><h3>『过零率ZCR』</h3><p>直接从字面意思上理解，过零率(zero-crossing rate)就是指波形在单位时间内的穿零次数。我们用下方的“动打动动打”音乐片段为例仔细了解下ZCR。</p><pre><ol><li><p><span><code><span>dongda, sr = librosa.load(</span><span>'attachment/mir02-dongda.wav'</span><span>)</span></code></span></p></li><li><p><span><code><span>ipd.</span><span>Audio</span><span>(dongda, rate=sr)</span></code></span></p></li></ol></pre><p></mpvoice></p><p>以采样率 <code><span>sr</span></code>加载的音频文件，可得到 <code><span>len(dongda)=49613</span></code>个样本，把它们的数值沿时间轴画出来就得到该音频的波形：<br></p><pre><ol><li><p><span><code><span>plt.figure(figsize=(</span><span>14</span><span>, </span><span>5</span><span>))</span></code></span></p></li><li><p><span><code><span>librosa.display.waveplot(dongda, sr=sr)</span></code></span></p></li></ol></pre><p><img src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJW5ibULYpq3DukKPbQrgxPlLia9DxOUNVfP5RsvTR63FnyiaVUFb434HhYdhKErs5Mvtn10icYIRichiaQg/640"></p><p>假设我们手上有个放大器，现在仔细观察下第6500到7500个之间1000个样本的波形变化：<br></p><pre><ol><li><p><span><code><span>n0 = </span><span>6500</span></code></span></p></li><li><p><span><code><span>n1 = </span><span>7500</span></code></span></p></li><li><p><span><code><span>plt.figure(figsize=(</span><span>14</span><span>, </span><span>5</span><span>))</span></code></span></p></li><li><p><span><code><span>plt.plot(dongda[n0:n1])</span></code></span></p></li><li><p><span><code><span>plt.axhline(</span><span>0</span><span>,linestyle=</span><span>'dashed'</span><span>,color=</span><span>'grey'</span><span>)</span></code></span></p></li></ol></pre><p><img src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJW5ibULYpq3DukKPbQrgxPlLSEXQHHElsYibNH49fJcrTHnQYAQ4EZCN1HP1k8ZISc9syCjuYqIibQYg/640"></p><p>可以直接从上图观察到该波形穿过界限0一共有5次，也可以用代码计算次数：<br></p><pre><ol><li><p><span><code><span>zero_crossings = librosa.zero_crossings(dongda[n0:n1], pad=</span><span>False</span><span>)</span></code></span></p></li></ol></pre><p>得到的 <code><span>zero_crossings</span></code>是一个由 <code><span>True</span></code>或 <code><span>False</span></code>组成的长度同样为1000的向量， <code><span>True</span></code>表示的是在该位置上的输入样本发生了“过零”，因此若计算过零总次数只需要进行一下求和操作：</p><pre><ol><li><p><span><code><span>sum(zero_crossings)</span></code></span></p></li></ol></pre><p>针对于整个音频数据，以2048个样本为一帧，计算该帧下过零率，再跳过512个样本继续计算下一帧内的过零率：</p><pre><ol><li><p><span><code><span>zcrs_init = librosa.feature.zero_crossing_rate(dongda)</span></code></span></p></li><li><p><span><code></code></span></p></li><li><p><span><code><span># 画出音频波形和每一帧下的过零率</span></code></span></p></li><li><p><span><code><span>plt.figure(figsize=(</span><span>14</span><span>, </span><span>5</span><span>))</span></code></span></p></li><li><p><span><code><span>zcrs_times = librosa.frames_to_time(np.arange(len(zcrs_init[</span><span>0</span><span>])), sr=sr, hop_length=</span><span>512</span><span>)</span></code></span></p></li><li><p><span><code><span>librosa.display.waveplot(dongda, sr=sr, alpha=</span><span>0.7</span><span>)</span></code></span></p></li><li><p><span><code><span>plt.plot(zcrs_times,zcrs_init[</span><span>0</span><span>], label=</span><span>'ZCR'</span><span>, lw=</span><span>3</span><span>, color=</span><span>'green'</span><span>)</span></code></span></p></li><li><p><span><code><span>plt.legend()</span></code></span></p></li></ol></pre><p><img src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJW5ibULYpq3DukKPbQrgxPlLbQcFy3lkr3y8vahQBwVfXLB3uJ6iaExIq6bcwRvPJbYgqjtn6L9n7CQ/640"></p><p>✎ 我们会发现过零率高的区域恰巧对应了该“动打动动打”音频中“打”的部分，其实“动”是底鼓而“打”是小鼓的声音，底鼓声音的频率较低所以也听上去非常沉稳，而小鼓频率较高听上去“精神多了”，声音的频率高则其在单位时间内拥有更多波形周期，因此单位时间内过零数会更多，那么过零率就更高。<br></p><p>✎ 音频最开始的“无声”区域，其实是有许多非常小数值的样本在界限0的周围转悠，所以也得到了较高的过零率。我们可以先给整个音频样本的数值都加个小小的常数，消除这些小数值对过零率计算的影响：</p><pre><ol><li><p><span><code><span>zcrs = librosa.feature.zero_crossing_rate(dongda + </span><span>0.0001</span><span>)</span></code></span></p></li><li><p><span><code></code></span></p></li><li><p><span><code><span># 画出音频波形和每一帧的过零率（绿线）vs处理后得到的过零率（橙线）</span></code></span></p></li><li><p><span><code><span>plt.figure(figsize=(</span><span>14</span><span>, </span><span>5</span><span>))</span></code></span></p></li><li><p><span><code><span>zcrs_times = librosa.frames_to_time(np.arange(len(zcrs[</span><span>0</span><span>])), sr=sr, hop_length=</span><span>512</span><span>)</span></code></span></p></li><li><p><span><code><span>librosa.display.waveplot(dongda, sr=sr, alpha=</span><span>0.7</span><span>)</span></code></span></p></li><li><p><span><code><span>plt.plot(zcrs_times,zcrs[</span><span>0</span><span>], label=</span><span>'Processed ZCR'</span><span>, lw=</span><span>4</span><span>, color=</span><span>'orange'</span><span>)</span></code></span></p></li><li><p><span><code><span>plt.plot(zcrs_times,zcrs_init[</span><span>0</span><span>], label=</span><span>'Initial ZCR'</span><span>, lw=</span><span>2</span><span>, alpha=</span><span>0.5</span><span>, color=</span><span>'green'</span><span>)</span></code></span></p></li><li><p><span><code><span>plt.legend()</span></code></span></p></li></ol></pre><p><img src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJW5ibULYpq3DukKPbQrgxPlL548aFlia9jLTlJOctsxFOHhHha1IEnXCyE1S15CBdkENcPmYKHoPpKA/640"></p><hr><h3>『自相关』</h3><p>自相关(autocorrelation)也叫序列相关，可以描述一个信号与其沿时间轴位移后的版本之间的相似度。</p><p><img src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJW5ibULYpq3DukKPbQrgxPlL8ibA4Zw3GGQUA9GvYia6f3DdicLlovhoBBmoZxmtlpPBaFB3u9lLBKxicg/640"></p><p>公式中的 <code><span>k</span></code>是时移参数(lag)，很明显当 <code><span>k=0</span></code>时得到的 <code><span>r</span></code>值最大，也就是信号与信号本身相似度是最大的。<br></p><p>假设该信号是一个周期信号，则该信号与“移动了一个周期长度的该信号”之间的自相关也会返回一个峰值，因此可以估计出周期信号的频率。</p><p>可见自相关是一种找出重复模式的数学工具，在MIR领域中可用自相关算法估计乐曲的节奏型，也可以估计单旋律音乐中的基频，著名的YIN算法第一步就是自相关！</p><p><span>☞ YIN算法的论文出处：</span></p><p><span>De Cheveigné, Alain, and Hideki Kawahara. "YIN, a fundamental frequency estimator for speech and music." The Journal of the Acoustical Society of America 111.4 (2002): 1917-1930.</span></p><p>✎ 我们就用双簧管吹奏的1秒单音音频为输入，用自相关简单实现下如何估计音频里基频：</p><pre><ol><li><p><span><code><span>oboe_data, sr = librosa.load(</span><span>'attachment/mir02-oboe_C6_1046Hz.wav'</span><span>)</span></code></span></p></li><li><p><span><code><span>ipd.</span><span>Audio</span><span>(oboe_data, rate=sr)</span></code></span></p></li></ol></pre><p>假设已知音频中的音高在A0到C8之间即基频范围在：</p><pre><ol><li><p><span><code><span>f_low = </span><span>27.5</span></code></span></p></li><li><p><span><code><span>f_high = </span><span>4186.01</span></code></span></p></li></ol></pre><p>则对应的最小与最大k为：</p><pre><ol><li><p><span><code><span>k_high = sr/f_low</span></code></span></p></li><li><p><span><code><span>k_low = sr/f_high</span></code></span></p></li></ol></pre><p>在此条件下计算其自相关，且不考虑 <code><span>k_high</span></code>以上的时移，并将得到的自相关中小于 <code><span>k_low</span></code>的部分置零：</p><pre><ol><li><p><span><code><span>r = librosa.autocorrelate(oboe_data, max_size=</span><span>int</span><span>(k_high))</span></code></span></p></li><li><p><span><code><span>r[:</span><span>int</span><span>(k_low)] = </span><span>0</span></code></span></p></li><li><p><span><code></code></span></p></li><li><p><span><code><span># 画出自相关结果</span></code></span></p></li><li><p><span><code><span>plt.figure(figsize=(</span><span>14</span><span>, </span><span>5</span><span>))</span></code></span></p></li><li><p><span><code><span>plt.plot(r)</span></code></span></p></li></ol></pre><p><img src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJW5ibULYpq3DukKPbQrgxPlLPMje3XSKAXPUKdKHDyoJ36E4VP0oVEjJ79wicNTQQF2KUV72QZ2qT5Q/640"></p><p>✎ 在以上结果中取纵轴数值最大处对应的横轴k的值，即为基频对应的时移参数：<br></p><pre><ol><li><p><span><code><span>k_fundamental = r.argmax()</span></code></span></p></li><li><p><span><code><span>print</span><span>(k_fundamental)</span></code></span></p></li></ol></pre><p>➥ 可显示结果为21</p><p>✎ 则基频为：</p><pre><ol><li><p><span><code><span>print</span><span>(</span><span>"{} Hz"</span><span>.format(sr/k_fundamental))</span></code></span></p></li></ol></pre><p>➥ 可显示结果为1050.0 Hz</p><p>✎ 事实上音频中双簧管吹奏的音高是C6（midi数值为84），其基频为：</p><pre><ol><li><p><span><code><span>print</span><span>(</span><span>"{} Hz"</span><span>.format(librosa.midi_to_hz(</span><span>84</span><span>)))</span></code></span></p></li></ol></pre><p>➥ 1046.5022612023945 Hz</p><p>可见与我们用自相关估计出的基频还是很接近的！</p><p>不过当音频是复调音乐，即同一时刻不止会有一个音被演奏，用自相关估计基频/音高就有些力不从心了 <code><span>_(:3」∠)_</span></code></p><hr><p><span>上文回顾：</span><a href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483704&amp;idx=1&amp;sn=e6705ea9535890e16f87a9b1c7956226&amp;chksm=fe0d9f97c97a16815ac0df35d02ef2d66eb14644589f05ab8aec8f407c2c9d31ced863f6240f&amp;scene=21#wechat_redirect" target="_blank"><span>「MIR-02_1」音频特征小全之概览</span></a></p>
+    </div>
+  </article>
+</body>
+</html>

--- a/articles/audio-feature-tools.html
+++ b/articles/audio-feature-tools.html
@@ -1,0 +1,581 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>「MIR-02_4」音频特征小全之提取工具 - 无痛入门音乐科技</title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「MIR-02_4」音频特征小全之提取工具</h1>
+      <div class="meta">2019年11月13日 10:11 · 无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>工欲善其事必先利其器，可自动提取音频特征的工具有哪些？</p>
+        </blockquote>
+        <p>
+          <strong
+            ><span>♬ 本文为MIR音乐信息检索系列的第2.5篇文章 ♬</span></strong
+          >
+        </p>
+        <p>
+          <strong
+            ><span
+              >♬
+              该文与之前2.1概览+2.2时域特征+2.3频域特征及+2.4乐音特征共同组成音频特征小全
+              ♬</span
+            ></strong
+          >
+        </p>
+        <p><span>本文将大致介绍以下特征提取工具：</span></p>
+        <ul>
+          <li>
+            <p><span>基于Python</span></p>
+          </li>
+          <li>
+            <p><span>基于Matlab</span></p>
+          </li>
+          <li>
+            <p><span>其他Toolbox</span></p>
+          </li>
+        </ul>
+        <hr />
+        <h2><span>『基于Python的工具』</span></h2>
+        <p>
+          <strong><span>☞</span> LibROSA</strong> |
+          算是最常用的音乐音频工具，可做各种时频变换并画图，也能提相应的频域特征，此外还能做基本的音符起始点检测、节拍检测、乐音与噪声分离等等。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://librosa.github.io/librosa"
+              target="_blank"
+              rel="noopener"
+              >https://librosa.github.io/librosa</a
+            ></span
+          >
+        </p>
+        <p>
+          <strong><span>☞</span> Madmom</strong> |
+          和LibROSA类似，但更针对于音符起始点和节拍检测等时域相关的MIR任务。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://madmom.readthedocs.io"
+              target="_blank"
+              rel="noopener"
+              >https://madmom.readthedocs.io</a
+            ></span
+          >
+        </p>
+        <p>还有一些Python包支持某特定的MIR任务，如：</p>
+        <p>
+          <strong><span>☞</span> MSAF</strong> | 可做歌曲结构的分析。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://github.com/urinieto/msaf"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/urinieto/msaf</a
+            ></span
+          >
+        </p>
+        <p>
+          <strong
+            ><strong><span>☞</span>&nbsp;</strong>Muda</strong
+          >
+          | 可用于扩增音频数据量，方便用于深度学习。
+        </p>
+        <p>
+          <span
+            >➥
+            <a href="https://muda.readthedocs.io" target="_blank" rel="noopener"
+              >https://muda.readthedocs.io</a
+            ></span
+          >
+        </p>
+        <p>
+          <strong
+            ><strong><span>☞</span>&nbsp;</strong>mir_eval</strong
+          >
+          | 可用于计算常见MIR任务相关算法的评估分数。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://github.com/craffel/mir_eval"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/craffel/mir_eval</a
+            ></span
+          >
+        </p>
+        <hr />
+        <h2><span>『基于Matlab的工具』</span></h2>
+        <p>
+          <strong
+            ><strong><span>☞</span>&nbsp;</strong>MIRtoolbox</strong
+          >
+          | 可提取乐音特征，如音频里的调性等。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://www.jyu.fi/hytk/fi/laitokset/mutku/en/research/materials/mirtoolbox"
+              target="_blank"
+              rel="noopener"
+              >https://www.jyu.fi/hytk/fi/laitokset/mutku/en/research/materials/mirtoolbox</a
+            ></span
+          >
+        </p>
+        <p>
+          <strong
+            ><strong><span>☞</span>&nbsp;</strong>Chroma Toolbox</strong
+          >
+          | 可提取和音高有关的诸多色度特征(chroma)。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://www.audiolabs-erlangen.de/resources/MIR/chromatoolbox"
+              target="_blank"
+              rel="noopener"
+              >https://www.audiolabs-erlangen.de/resources/MIR/chromatoolbox</a
+            ></span
+          >
+        </p>
+        <p>
+          <strong
+            ><strong><span>☞</span>&nbsp;</strong>Constant-Q Toolbox</strong
+          >
+          | 可做常数Q变换并基于此改变输入音频中的音高。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://www.cs.tut.fi/sgn/arg/CQT"
+              target="_blank"
+              rel="noopener"
+              >https://www.cs.tut.fi/sgn/arg/CQT</a
+            ></span
+          >
+        </p>
+        <p>
+          <strong
+            ><strong><span>☞</span>&nbsp;</strong>Tempogram Toolbox</strong
+          >
+          | 可提取用于做节拍检测的不同tempogram。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="http://resources.mpi-inf.mpg.de/MIR/tempogramtoolbox"
+              target="_blank"
+              rel="noopener"
+              >http://resources.mpi-inf.mpg.de/MIR/tempogramtoolbox</a
+            ></span
+          >
+        </p>
+        <hr />
+        <h2><span>『其他Toolbox』</span></h2>
+        <p>
+          <strong
+            ><strong><span>☞</span>&nbsp;</strong>Essentia</strong
+          >
+          |
+          基于C++，可提取各种音频底层高层、时域频域等诸多特征，也可直接运行一些MIR任务。
+        </p>
+        <p>
+          <span
+            >➥
+            <a href="http://essentia.upf.edu/" target="_blank" rel="noopener"
+              >http://essentia.upf.edu/</a
+            ></span
+          >
+        </p>
+        <p>
+          <strong
+            ><strong><span>☞</span>&nbsp;</strong>Marsyas</strong
+          >
+          | 基于C++，可用其界面或命令行进行实时特征提取。
+        </p>
+        <p>
+          <span
+            >➥
+            <a href="http://marsyas.info/" target="_blank" rel="noopener"
+              >http://marsyas.info/</a
+            ></span
+          >
+        </p>
+        <p>
+          <strong
+            ><strong><span>☞</span>&nbsp;</strong>YAAFE</strong
+          >
+          | 基于C++，也可在Python和Matlab里调用，主要提取底层的特征。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="http://yaafe.github.io/Yaafe/"
+              target="_blank"
+              rel="noopener"
+              >http://yaafe.github.io/Yaafe/</a
+            ></span
+          >
+        </p>
+        <p>
+          <strong
+            ><strong><span>☞</span>&nbsp;</strong>aubio</strong
+          >
+          | 基于C，也可在Python里调用，可做音高追踪、节拍追踪等。
+        </p>
+        <p>
+          <span
+            >➥
+            <a href="https://aubio.org/" target="_blank" rel="noopener"
+              >https://aubio.org/</a
+            ></span
+          >
+        </p>
+        <p>
+          <strong
+            ><strong><span>☞</span>&nbsp;</strong>LibXtract</strong
+          >
+          | 杂糅了C/Max-MSP/Pure Data/Super Collider/Vamp可实时提取底层特征。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="http://jamiebullock.github.io/LibXtract/documentation/"
+              target="_blank"
+              rel="noopener"
+              >http://jamiebullock.github.io/LibXtract/documentation/</a
+            ></span
+          >
+        </p>
+        <p>
+          <strong
+            ><strong><span>☞</span>&nbsp;</strong>jAudio</strong
+          >
+          | 基于Java可批量提取特征并输出为XML和ARFF格式。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="http://jaudio.sourceforge.net/"
+              target="_blank"
+              rel="noopener"
+              >http://jaudio.sourceforge.net/</a
+            ></span
+          >
+        </p>
+        <p>
+          <strong
+            ><strong><span>☞</span>&nbsp;</strong>jMIR</strong
+          >
+          |
+          基于Java，主要用于音乐分类任务的研究。除了可处理音频，也提供分析乐谱/歌词等其他音乐信息的功能。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="http://jmir.sourceforge.net/"
+              target="_blank"
+              rel="noopener"
+              >http://jmir.sourceforge.net/</a
+            ></span
+          >
+        </p>
+        <p>
+          <strong
+            ><strong><span>☞</span>&nbsp;</strong>Meyda</strong
+          >
+          | 基于Javascript，主要用于网页端提取底层音频特征的开发。
+        </p>
+        <p>
+          <span
+            >➥
+            <a href="https://meyda.surge.sh/" target="_blank" rel="noopener"
+              >https://meyda.surge.sh/</a
+            ></span
+          >
+        </p>
+        <hr />
+        <section>
+          另外推荐使用<strong>Sonic Visualiser</strong
+          >来“可视化”被提取出的特征随当前播放音频的变化，特征可使用<strong
+            >Sonic Annotator</strong
+          >中集成的<strong>Vamp Plugins</strong
+          >提取，也可自己编译Plugin进行提取！
+        </section>
+        <section>
+          <span
+            >➥
+            <a
+              href="https://www.sonicvisualiser.org/"
+              target="_blank"
+              rel="noopener"
+              >https://www.sonicvisualiser.org/</a
+            ></span
+          >
+        </section>
+        <section>
+          <span
+            >➥
+            <a
+              href="https://vamp-plugins.org/sonic-annotator/"
+              target="_blank"
+              rel="noopener"
+              >https://vamp-plugins.org/sonic-annotator/</a
+            ></span
+          >
+        </section>
+        <section>
+          <span
+            >➥
+            <a
+              href="https://vamp-plugins.org/index.html"
+              target="_blank"
+              rel="noopener"
+              >https://vamp-plugins.org/index.html</a
+            ></span
+          >
+        </section>
+        <hr />
+        <section>
+          <strong><span>上文回顾：</span></strong>
+        </section>
+        <ul>
+          <li>
+            <p>
+              <a
+                href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483704&amp;idx=1&amp;sn=e6705ea9535890e16f87a9b1c7956226&amp;chksm=fe0d9f97c97a16815ac0df35d02ef2d66eb14644589f05ab8aec8f407c2c9d31ced863f6240f&amp;scene=21#wechat_redirect"
+                target="_blank"
+                data-itemshowtype="0"
+                data-linktype="2"
+                ><span>「MIR-02_1」音频特征小全之概览</span></a
+              >
+            </p>
+          </li>
+          <li>
+            <section>
+              <a
+                href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483733&amp;idx=1&amp;sn=e880a75645ad92e49fe9b80f5b5d5b67&amp;chksm=fe0d9ffac97a16ecc093ee5461812d9010134755a5642244200054cad693e99749fae18cc25d&amp;scene=21#wechat_redirect"
+                target="_blank"
+                data-itemshowtype="0"
+                data-linktype="2"
+                ><span>「MIR-02_2」音频特征小全之时域特征</span></a
+              ><br />
+            </section>
+          </li>
+          <li>
+            <section>
+              <a
+                href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483747&amp;idx=1&amp;sn=3651815c811239e4d68fd6901132c87b&amp;chksm=fe0d9fccc97a16da88eccd6c5aaf7f69d0fa00be2b785016779a7b03be29a244c4e72ffe0175&amp;scene=21#wechat_redirect"
+                target="_blank"
+                data-itemshowtype="0"
+                data-linktype="2"
+                ><span>「MIR-02_3」音频特征小全之频域特征</span></a
+              ><br />
+            </section>
+          </li>
+          <li>
+            <section>
+              <a
+                href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483756&amp;idx=1&amp;sn=b2fc7cf0396fda41b50b02d377e45e77&amp;chksm=fe0d9fc3c97a16d57f9b02177f30d63bbc2e55adb4be88f50149b2d6808b05ab0d43f74534e8&amp;scene=21#wechat_redirect"
+                target="_blank"
+                data-itemshowtype="0"
+                data-linktype="2"
+                ><span>「MIR-02_4」音频特征小全之乐音特征</span></a
+              ><br />
+            </section>
+          </li>
+        </ul>
+        <p><br /></p>
+        <p><br /></p>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/audio-fingerprint.html
+++ b/articles/audio-fingerprint.html
@@ -1,0 +1,443 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>「MIR-03」听歌识曲: 音乐宇宙里的占星师 - 无痛入门音乐科技</title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「MIR-03」听歌识曲: 音乐宇宙里的占星师</h1>
+      <div class="meta">2020年3月7日 17:00 · 无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            听歌识曲可以让"求BGM名"不再是个问题, 这背后的算法,
+            就如同一个看遍音乐宇宙星图的占星大师傅, 自动为你求解!<br />
+          </p>
+        </blockquote>
+        <p>
+          <span><strong>♬ 本文为MIR音乐信息检索系列的第7篇文章 ♬</strong></span>
+        </p>
+        <p>
+          <span
+            >先用我刚刚录的30秒视频,
+            演示下QQ音乐App里的听音识曲功能:&nbsp;</span
+          >
+        </p>
+        <p>
+          <span
+            >可见3秒就能把音频识别出来, 不仅返回歌曲基础信息,
+            更是直接定位到当前播放的时间戳.&nbsp;我的好友&amp;同事鲁霄大兄弟,
+            已经通过QQ音乐的知乎账号发表了4篇技术系列文章,&nbsp;并在MIREX&nbsp;2019
+            Audio Fingerprinting竞赛中取得了第一名!&nbsp;所以我这篇更偏科普,
+            争取让大家无痛入门~</span
+          ><br />
+        </p>
+        <p>
+          <span
+            >之所以说整个过程像占星,&nbsp;是因为给定音频片段的指纹与整个曲库的指纹在匹配过程中,
+            好比在星图中认出一个星座, 而音频指纹与星图在地球上空的样子,
+            更是有异曲同工之妙.</span
+          ><br />
+        </p>
+        <p>
+          <img
+            data-original-style="width: 100%;height: auto;"
+            data-index="2"
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJVqK5EsaG75Res8FytqrA28RiaiaLIGYc0On1F1ibibWuvWkKdibHWenOdjnicl6EsuBfSBSSHo6eT2LJ9A/640"
+            _width="100%"
+            alt="Image"
+            data-report-img-idx="0"
+          />
+        </p>
+        <p>
+          <span
+            >接下来, 我将回答以下三个问题,
+            带大家一步步地了解听歌识曲的原理：</span
+          >
+        </p>
+        <ul>
+          <li>
+            <p><span>什么是音频指纹?</span></p>
+          </li>
+          <li>
+            <p><span>如何从音频指纹中获得Hashes?</span></p>
+          </li>
+          <li>
+            <p><span>如何用Hashes进行歌曲匹配？</span></p>
+          </li>
+        </ul>
+        <hr />
+        <h3>『音频指纹』</h3>
+        <p>
+          <span
+            >音频指纹就如人的指纹一样,&nbsp;可以有效地代表一首歌.&nbsp;因为听歌识曲做匹配时,
+            是和曲库千万级歌曲做比对, 那么音频指纹就要足够<strong>精简</strong>,
+            才能3秒内就算出匹配结果;
+            同时,&nbsp;音频指纹还要有足够的<strong>辨识度</strong>,&nbsp;比如在"求问背景音乐是什么"这个场景下,&nbsp;不可避免地有其他音频信号掺杂其中(比如男女主在说话),
+            那背景音乐的音频指纹如何在干扰环境下依然脱颖而出?</span
+          >
+        </p>
+        <p>
+          <span
+            >那让我们仰望上图的星空,&nbsp;看到由中间几颗星星辨识出的天蝎座,
+            其实星座本身不止有这些星星,
+            只是它们总是最亮的那几颗,&nbsp;亮到抗得住地球天空状态的干扰. 同理,
+            如果能挑出音频里最亮的星星, 构成其指纹, 不就妥妥的了?<br
+          /></span>
+        </p>
+        <p>
+          <span
+            >业界第一个开发音频指纹的公司Shazam, 也是这么想的:
+            挑出"音频波形进行STFT变换后得到的spectrogram"里高能量的峰点们,
+            构成constellation map星云图, 也就是这个音频的指纹模样了!</span
+          >
+        </p>
+        <p>
+          <img
+            data-original-style="width: 100%;height: auto;"
+            data-index="3"
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJVqK5EsaG75Res8FytqrA28cj1APKmyuaEahFV29icsyicquCzdcPLRGBWMKUyr0iaCSib6W6KkK4sGpQ/640"
+            _width="100%"
+            alt="Image"
+          />
+        </p>
+        <p>
+          <span
+            ><span>☞&nbsp;</span>不记得spectrogram是什么了? 回看<a
+              target="_blank"
+              href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483684&amp;idx=1&amp;sn=d3f3746a6837f7d12044d1931cfd4ead&amp;chksm=fe0d9f8bc97a169dbfcb80443e8da87d8e35ae643bae76841060442d8f88a4f292cda594afa5&amp;scene=21#wechat_redirect"
+              data-itemshowtype="0"
+              tab="innerlink"
+              data-linktype="2"
+              >「MIR-01」要把音乐画出来，总共分几步？</a
+            ></span
+          ><br />
+        </p>
+        <p>
+          <span
+            >至此算是给出了解决"辨识度"的方案,
+            那如何用更精简有效的数据格式表示星云图?&nbsp;答案是<strong>Hashes</strong>.</span
+          >
+        </p>
+        <hr />
+        <h3>『Hashes』</h3>
+        <p>
+          <span
+            >最最简单的表示方式, 莫过于直接用 [(4s, 800Hz), (7s, 1000Hz), (10s,
+            1700Hz)]
+            这样的方式表示图1B中的点,&nbsp;然而问题是,&nbsp;4s/7s/10s只是当前这个音频片段a里的时间信息,&nbsp;但这个音频片段很可能出自于某首歌A里的第44s/47s/50s,&nbsp;拿着这种形式的时间信息去做匹配并没有什么用...</span
+          >
+        </p>
+        <p>
+          <span
+            >更何况, 听歌识曲实现的是,&nbsp;听一丢丢片段, 就能知道是哪首歌.
+            利用<span>[</span><span>(</span><span>4s, 800Hz</span><span>)</span
+            ><span>, (7s, 1000</span><span>Hz</span><span>)</span><span>,</span
+            ><span> (10s, 1700Hz</span><span>)</span
+            ><span>]&nbsp;</span>这样的数据, 算法就只能从头到尾听完整首歌,
+            才能识别出来了.</span
+          >
+        </p>
+        <p>
+          <span
+            >因此,&nbsp;相比于用绝对的时间和频率的值,
+            不如用<strong>相对</strong>的数据:&nbsp;将一个点(t1, f1),
+            与其之后的一个点(t2, f2), 这一对表示为由3个数值构成的一个<strong
+              >hash = f1: f2:&nbsp;t2-t1&nbsp;</strong
+            ></span
+          ><span
+            >这样把音频里所有一对对存储成hashes,&nbsp;在音乐意义上就是存储了当前音频中,
+            能被明显听到的音符们, 在发生音程变化时所用的时间.</span
+          >
+        </p>
+        <p>
+          <img
+            data-original-style="width: 100%;height: auto;"
+            data-index="4"
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJVqK5EsaG75Res8FytqrA28dLkwPL1RbTiaLiafHYa25Af7x6ibic6VoE1DOMCs8O7a8NAMZVibJqXGN5A/640"
+            _width="100%"
+            alt="Image"
+          />
+        </p>
+        <p><span></span></p>
+        <hr />
+        <h3>『匹配流程』</h3>
+        <p>
+          <span
+            >当我们拥有曲库所有歌曲各自的hashes,&nbsp;你想让App识别的歌曲片段a的hashes也被计算出来之后,
+            匹配过程无非是:&nbsp;当hashes(a)与曲库中一首歌A的hashes(A)呈现出最大数量的匹配hash,
+            那么这个歌曲片段a很有可能来自于歌曲A.</span
+          >
+        </p>
+        <p>
+          <span
+            >但是问题又来了!&nbsp;"最大数量的匹配hash"没有考虑hash的先后次序,&nbsp;仅仅通过这个条件判定识别结果会有什么后果?&nbsp;比如歌曲片段a听上去应该是小星星的旋律:&nbsp;C
+            C G G&nbsp;A A G 且音符之间均隔0.5秒;
+            这时曲库里有一首歌B,&nbsp;在开头2秒出现了A A G, 中间副歌100秒时出现C
+            C G G, 最后结束的2秒出现了G A.
+            这种情况时,&nbsp;hashes(a)也都被包含在hashes(B)里呈现最大数量的匹配,
+            但明显不能说片段a来自于歌曲B呀!<br
+          /></span>
+        </p>
+        <p>
+          <span
+            >解决办法是,
+            当<span>hashes(a)</span>有个hash匹配hashes(A)的一个hash时,
+            记录该hash分别在片段a和歌曲A中的时间戳, 以下图为例:&nbsp;</span
+          >
+        </p>
+        <p>
+          <img
+            data-original-style=""
+            data-index="5"
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJVqK5EsaG75Res8FytqrA28aYtrkDSoHkic4vDkZppGvAlCDjUZia5iaIcApte8CmdsM0PVKm5icdmS6A/640"
+            _width="677px"
+            alt="Image"
+          />
+        </p>
+        <p>
+          <span
+            >上图中, 歌曲片段a (sample soundfile) 共25秒,&nbsp;曲库里的一首歌曲A
+            (database soundfile) 共100秒, 在其第40秒到60多秒之间,
+            有很多和hashes(a)的匹配, 这里每一个匹配都用一个蓝圆圈表示.<br
+          /></span>
+        </p>
+        <p>
+          <span
+            >若将圆圈对应的database soundfile time减去sample soundfile
+            time,&nbsp;可得大部分时间差为40s,
+            具体时间差得出的直方图分布如下所示:</span
+          >
+        </p>
+        <p>
+          <img
+            data-original-style="width: 100%;height: auto;"
+            data-index="6"
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJVqK5EsaG75Res8FytqrA28k4T6dkfP0HL9m7xCoNsjm1icmSaPZiaTl3pYWfdLhkMUaY5IiaY37SVCg/640"
+            _width="100%"
+            alt="Image"
+          />
+        </p>
+        <p>
+          <span
+            >可以推断<strong
+              >片段a应该就是歌曲A中第40秒到第65秒的片段,
+              听歌识曲结果返回歌曲A!&nbsp;</strong
+            ></span
+          ><span>如果是片段a和反例中的</span><span>曲</span><span>库歌曲</span
+          ><span>B做匹配</span><span>, </span><span>那</span
+          ><span>上面同样的两</span><span>个图示</span><span>就</span
+          ><span>会呈现出</span><span>:</span>
+        </p>
+        <p>
+          <img
+            data-original-style="width: 100%;height: auto;"
+            data-index="7"
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJVqK5EsaG75Res8FytqrA28GRX0icMzj8Hia8gVjCXkCtbfbicyJTtFyx4w3aEhQ9DQ2J5XCHyVyfSeQ/640"
+            _width="100%"
+            alt="Image"
+          />
+        </p>
+        <p>
+          <span
+            >因此在数据库里真正存储歌曲的hashes时,
+            还需要存上每条hash在该歌曲中的时间戳 (</span
+          ><strong
+            >hash: time = [<strong>f1: f2:&nbsp;t2-t1</strong>]: t1</strong
+          ><span>)</span>
+        </p>
+        <hr />
+        <p>
+          <span
+            >通过以上的科普,
+            希望大家对听歌识曲的基本原理有了大概理解,&nbsp;其实还有许许多多科普文章里说不清楚的技术细节...&nbsp;</span
+          >
+        </p>
+        <p>
+          <span
+            >广告时间: 欢迎大家体验QQ音乐App里听歌识曲的功能,
+            另有专门的"<strong>Q音探歌</strong>"App请多支持!&nbsp;</span
+          >
+        </p>
+        <p>
+          <span
+            ><strong><span>✎ 文中图例来自文献</span></strong></span
+          ><strong><span>：</span></strong
+          ><span
+            >Avery Li-Chun Wang. "An industrial strength audio search
+            algorithm." In&nbsp;ISMIR, pp. 7-13. 2003.</span
+          >
+        </p>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/audio-music-tech-book.html
+++ b/articles/audio-music-tech-book.html
@@ -1,0 +1,414 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>「INFO」《音频音乐技术》正式出版 - 无痛入门音乐科技</title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「INFO」《音频音乐技术》正式出版</h1>
+      <div class="meta">2020年4月3日 15:33 · 无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            "音频音乐与计算机的交融——音频音乐技术"一书由50余位大学老师、公司博士和博士硕士研究生联合编写，历经3年终于由复旦大学出版社正式出版了！
+          </p>
+        </blockquote>
+        <p>
+          <strong
+            >♬
+            即日起可在京东/天猫/当当等各大网上书店订购！该书全文468页，895千字，对文理科声音与音乐技术的教学科研具有全面的参考价值
+            ♬</strong
+          >
+        </p>
+        <p>博主本人也非常荣幸作为50余编者之一，对书中第三章做了些贡献:)</p>
+        <p>
+          <img
+            src="https://mmbiz.qpic.cn/mmbiz_jpg/7CrMia15fFJWGYtHK7aicpickzTtFgJBnnicTsTmAK5YRniaoRxAqPpEqHJo2mNypDEhBOzk21TCQ3VU6dxGPTmFKBw/640"
+            alt="Image"
+          />
+        </p>
+        <hr />
+        <h3>『内容摘要』</h3>
+        <p>
+          近20年来，随着数字音频音乐的急剧增加，形成了音乐科技/音乐人工智能与计算机听觉/AI声学这一多领域交叉的新兴学科。本书全面介绍其主要内容，包括音频及音乐基础，音频特征及音频信号处理，常用机器学习技术，音乐信息检索MIR中的音高/旋律提取、自动记谱、节奏分析、和声分析、歌声信息处理、音乐搜索、音乐结构分析、音乐情感计算、音乐推荐、音乐分类，音乐生成中的自动作曲、歌声合成、数字乐器声合成，以及音乐演奏数据与建模，一般音频计算机听觉，音频信息安全，音频与视频和文本的融合，音乐制作、声景及声音设计，音乐录音、计算机交互与声音艺术，实用工具等内容。本书适合作为文理科涉及声音的课程教材及科研参考资料。
+        </p>
+        <hr />
+        <h3>『目录』</h3>
+        <ul>
+          <li><strong>前言</strong></li>
+          <li>
+            <strong>第一章 音频音乐技术概述</strong>
+            <ul>
+              <li>第一节 理解数字音乐——音乐信息检索技术综述</li>
+              <li>第二节 理解数字声音——基于一般音频／环境声的计算机听觉综述</li>
+            </ul>
+          </li>
+          <li>
+            <strong>第二章 音频基础</strong>
+            <ul>
+              <li>第一节 声学基础</li>
+              <li>第二节 心理声学及感知音频压缩</li>
+              <li>第三节 虚拟现实音频</li>
+              <li>第四节 基础乐理</li>
+            </ul>
+          </li>
+          <li>
+            <strong>第三章 音频特征及音频信号处理</strong>
+            <ul>
+              <li>第一节 音频特征</li>
+              <li>第二节 音频信号处理</li>
+            </ul>
+          </li>
+          <li>
+            <strong>第四章 常用的机器学习技术</strong>
+            <ul>
+              <li>第一节 监督学习方法</li>
+              <li>第二节 聚类分析</li>
+              <li>第三节 增强学习</li>
+              <li>第四节 生成对抗网络</li>
+              <li>第五节 集成学习</li>
+              <li>第六节 迁移学习</li>
+              <li>第七节 人工神经网络</li>
+              <li>第八节 深度学习</li>
+            </ul>
+          </li>
+          <li>
+            <strong>第五章 音高估计、主旋律提取与自动音乐记谱</strong>
+            <ul>
+              <li>第一节 音高估计</li>
+              <li>第二节 主旋律提取</li>
+              <li>第三节 自动音乐记谱</li>
+            </ul>
+          </li>
+          <li>
+            <strong>第六章 音乐节奏分析</strong>
+            <ul>
+              <li>第一节 音符起始点检测</li>
+              <li>第二节 节拍追踪</li>
+              <li>第三节 速度估计</li>
+              <li>第四节 节奏模式分析</li>
+              <li>第五节 节奏分析系统评估</li>
+            </ul>
+          </li>
+          <li>
+            <strong>第七章 和声分析</strong>
+            <ul>
+              <li>第一节 音乐和声基础</li>
+              <li>第二节 Chroma特征</li>
+              <li>第三节 和弦识别</li>
+              <li>第四节 调性估计</li>
+            </ul>
+          </li>
+          <li>
+            <strong>第八章 歌声信息处理</strong>
+            <ul>
+              <li>第一节 歌声检测</li>
+              <li>第二节 歌手识别</li>
+              <li>第三节 歌词识别</li>
+              <li>第四节 哼唱检索</li>
+            </ul>
+          </li>
+          <li>
+            <strong>第九章 音乐搜索</strong>
+            <ul>
+              <li>第一节 翻唱歌曲识别</li>
+              <li>第二节 音频指纹</li>
+              <li>第三节 音频水印</li>
+            </ul>
+          </li>
+          <li>
+            <strong>第十章 音乐结构分析</strong>
+            <ul>
+              <li>第一节 音乐结构分析概述</li>
+              <li>第二节 音乐结构分析方法</li>
+            </ul>
+          </li>
+          <li>
+            <strong>第十一章 音乐情感计算</strong>
+            <ul>
+              <li>第一节 音乐情感表示</li>
+              <li>第二节 音乐情感识别</li>
+              <li>第三节 音乐情感的其他研究方向</li>
+            </ul>
+          </li>
+          <li>
+            <strong>第十二章 音乐推荐</strong>
+            <ul>
+              <li>第一节 概述</li>
+              <li>第二节 协同过滤与内容的推荐算法</li>
+              <li>第三节 其他方面的推荐算法研究</li>
+            </ul>
+          </li>
+          <li>
+            <strong>第十三章 音乐分类</strong>
+            <ul>
+              <li>第一节 乐器识别</li>
+              <li>第二节 音乐标注</li>
+              <li>第三节 音乐流派分类</li>
+            </ul>
+          </li>
+          <li>
+            <strong>第十四章 自动作曲</strong>
+            <ul>
+              <li>第一节 概述</li>
+              <li>第二节 基于符号序列的模型</li>
+              <li>第三节 基于音频的模型</li>
+              <li>第四节 可控作曲与辅助作曲</li>
+            </ul>
+          </li>
+          <li>
+            <strong>第十五章 歌声合成</strong>
+            <ul>
+              <li>第一节 原理和方法</li>
+              <li>第二节 歌声合成技术的发展趋势</li>
+              <li>第三节 已有歌声合成系统</li>
+            </ul>
+          </li>
+          <li>
+            <strong>第十六章 数字乐器声合成</strong>
+            <ul>
+              <li>第一节 音频合成概述</li>
+              <li>第二节 音频合成类型</li>
+              <li>第三节 神经网络音频合成</li>
+            </ul>
+          </li>
+          <li>
+            <strong>第十七章 音乐演奏数据与建模</strong>
+            <ul>
+              <li>第一节 音乐表情</li>
+              <li>第二节 演奏评估</li>
+            </ul>
+          </li>
+          <li>
+            <strong>第十八章 一般音频计算机听觉</strong>
+            <ul>
+              <li>第一节 概述</li>
+              <li>第二节 音频事件检测与分类</li>
+              <li>第三节 声音场景分析</li>
+              <li>第四节 其他一般音频任务</li>
+            </ul>
+          </li>
+          <li>
+            <strong>第十九章 音频信息安全</strong>
+            <ul>
+              <li>第一节 音频信息安全概述</li>
+              <li>第二节 音频信息隐藏</li>
+              <li>第三节 音频取证</li>
+            </ul>
+          </li>
+          <li>
+            <strong>第二十章 音频与视频和文本的融合</strong>
+            <ul>
+              <li>第一节 概述</li>
+              <li>第二节 音频与视频信息融合</li>
+              <li>第三节 音频与文本信息融合</li>
+            </ul>
+          </li>
+          <li>
+            <strong>第二十一章 音乐制作、声景及声音设计</strong>
+            <ul>
+              <li>第一节 音乐制作</li>
+              <li>第二节 声景及声音设计</li>
+            </ul>
+          </li>
+          <li>
+            <strong>第二十二章 音乐录音、计算机交互与声音艺术</strong>
+            <ul>
+              <li>第一节 录音技术概述</li>
+              <li>第二节 音乐录音的关键技术</li>
+              <li>第三节 计算机交互音乐</li>
+              <li>第四节 计算机交互与声音艺术的思想理念</li>
+            </ul>
+          </li>
+          <li>
+            <strong>附录 音频音乐技术领域实用工具</strong>
+            <ul>
+              <li>附录一 音频与音乐科研数据库</li>
+              <li>附录二 MIREX竞赛简介</li>
+              <li>附录三 音频音乐技术领域期刊及会议</li>
+              <li>附录四 音频音乐领域研发机构及公司</li>
+              <li>附录五 中英文音频音乐专业术语</li>
+            </ul>
+          </li>
+          <li><strong>习题</strong></li>
+          <li><strong>参考文献</strong></li>
+          <li><strong>后记</strong></li>
+          <li><strong>编委会简介</strong></li>
+        </ul>
+        <hr />
+        <p>
+          最后再次感谢主编李伟老师，副主编李子晋和卲曦老师，以及50余位同行编者！希望大家支持这本如此系统介绍音频音乐技术的中文书籍！
+        </p>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/audio-preprocessing.html
+++ b/articles/audio-preprocessing.html
@@ -1,0 +1,886 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>
+      「MIR-06」打破砂锅问到底，不同python库做音频预处理的区别在哪里？ -
+      无痛入门音乐科技
+    </title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「MIR-06」打破砂锅问到底，不同python库做音频预处理的区别在哪里？</h1>
+      <div class="meta">2021年9月4日 16:37 · 无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            音频预处理通常是将原始波形处理为时频谱，即各种spectrograms，这一步可使用librosa或essentia，涉及到深度学习模型也可直接用torchaudio或tensorflow。但即使输入同个音频，采用同样的参数，得出的<span>时频谱</span>还是有细微差别。<br />
+          </p>
+        </blockquote>
+        <section>
+          <span
+            ><strong>♬ 本文为MIR音乐信息检索系列的第12篇文章 ♬</strong></span
+          >
+        </section>
+        <section>
+          <span
+            >因为代码块较多，手机上看有些麻烦，建议网页端浏览（之后我会整理详细代码，并同步到github）。</span
+          >
+        </section>
+        <section>
+          <span
+            >本文将大致讲解，使用librosa、essentia、torchaudio、tensorflow时：</span
+          >
+        </section>
+        <ul>
+          <li>
+            <section><span>通用参数的解释与设置</span></section>
+          </li>
+          <li>
+            <section><span>得出的spectrogram的区别</span></section>
+          </li>
+          <li>
+            <section>
+              <span><span>得出的mel filter bank的区别</span></span>
+            </section>
+          </li>
+          <li>
+            <section>
+              <span><span>得出的mel spectrogram的区别</span></span>
+            </section>
+          </li>
+        </ul>
+        <hr />
+        <h3>『通用参数设置』</h3>
+        <section>
+          <span
+            >安装在Linux机器下，各个python库均使用截止到2021年8月的最新稳定版本，分别为：<br
+          /></span>
+        </section>
+        <ul>
+          <li>
+            <section>
+              <span>librosa: version 0.8.1<br /></span>
+            </section>
+          </li>
+          <li>
+            <section><span>essentia: version 2.1b6.dev374</span></section>
+          </li>
+          <li>
+            <section>
+              <span>torchaudio: version 0.9.0, with torch 1.9.0</span>
+            </section>
+          </li>
+          <li>
+            <section><span>tensorflow: version 2.6.0</span></section>
+          </li>
+        </ul>
+        <p>
+          <span
+            >每个库中对音频预处理的默认参数不同，所以我们需要统一一下。鉴于tensorflow中可改的选项最不灵活，所以参数设置都向它对齐
+            (比如，tensorflow从linear到mel尺度进行转换时，依赖Hidden Markov
+            Model Toolkit
+            (HTK)，所以需统一NORM设置为None，且MEL_SCALE设置为'htk')。</span
+          >
+        </p>
+        <p>
+          <span
+            >下表列出我们统一设定的参数值，以及几个库中的参数名和默认值
+            (若有):</span
+          >
+        </p>
+        <table>
+          <tbody>
+            <tr>
+              <th width="125.33333333333333">
+                <span>参数</span><span>值统一设定为</span>
+              </th>
+              <th width="99.33333333333333">
+                <span>librosa默认值</span><br />
+              </th>
+              <th width="137.33333333333334">
+                <span>torchaudio默认值</span><br />
+              </th>
+              <th width="127.33333333333334">
+                <span>tensorflow默认值</span><br />
+              </th>
+            </tr>
+            <tr>
+              <td width="125.33333333333333" valign="top">
+                <span>SAMPLE_RATE=44100</span>
+              </td>
+              <td width="99.33333333333333" valign="top">
+                <span>sr=22050</span>
+              </td>
+              <td width="137.33333333333334" valign="top">
+                <span>sample_rate=16000</span>
+              </td>
+              <td width="127.33333333333334" valign="top">
+                <span>sample_rate</span>
+              </td>
+            </tr>
+            <tr>
+              <td width="125.33333333333333" valign="top">
+                <span>N_FFT=2048</span>
+              </td>
+              <td width="99.33333333333333" valign="top">
+                <span>n_fft=2048</span>
+              </td>
+              <td width="137.33333333333334" valign="top">
+                <span>n_fft=400</span>
+              </td>
+              <td width="127.33333333333334" valign="top">
+                <p><span>fft_length=</span><span>frame_length</span></p>
+              </td>
+            </tr>
+            <tr>
+              <td width="125.33333333333333" valign="top">
+                <span>HOP_LENGTH=512</span>
+              </td>
+              <td width="99.33333333333333" valign="top">
+                <span>hop_length=512</span>
+              </td>
+              <td width="137.33333333333334" valign="top">
+                <p>
+                  <span>hop_length</span><span>=</span
+                  ><span>win_length//2</span>
+                </p>
+              </td>
+              <td width="127.33333333333334" valign="top">
+                <span>frame_step</span>
+              </td>
+            </tr>
+            <tr>
+              <td width="125.33333333333333" valign="top">
+                <span>WIN_LENGTH=N_FFT&nbsp;</span>
+              </td>
+              <td width="99.33333333333333" valign="top">
+                <span>win_length=n_fft</span>
+              </td>
+              <td width="137.33333333333334" valign="top">
+                <span>win_length=n_fft</span>
+              </td>
+              <td width="127.33333333333334" valign="top">
+                <span>frame_length</span>
+              </td>
+            </tr>
+            <tr>
+              <td width="125.33333333333333" valign="top">
+                <span>WINDOW='hann'</span>
+              </td>
+              <td width="99.33333333333333" valign="top">
+                <span>window='hann'</span>
+              </td>
+              <td width="137.33333333333334" valign="top">
+                <p><span>window_fn</span><span>=</span></p>
+                <p><span>torch.hann_window</span></p>
+                <p>
+                  <span><span></span></span>
+                </p>
+              </td>
+              <td width="127.33333333333334" valign="top">
+                <p><span>window_fn=</span></p>
+                <p><span>tf.signal.hann_window</span></p>
+              </td>
+            </tr>
+            <tr>
+              <td width="125.33333333333333" valign="top">
+                <span>CENTER=False</span>
+              </td>
+              <td width="99.33333333333333" valign="top">
+                <span>center=True</span>
+              </td>
+              <td width="137.33333333333334" valign="top">
+                <span>center=True</span>
+              </td>
+              <td width="127.33333333333334" valign="top">
+                <span>分帧无法center<br /></span>
+              </td>
+            </tr>
+            <tr>
+              <td width="125.33333333333333" valign="top">
+                <span>PAD_END=False</span>
+              </td>
+              <td width="99.33333333333333" valign="top">
+                <span>pad_mode='reflect'</span>
+              </td>
+              <td width="137.33333333333334" valign="top">
+                <span>pad_mode='reflect'</span>
+              </td>
+              <td width="127.33333333333334" valign="top">
+                <span>pad_end=False<br /></span>
+              </td>
+            </tr>
+            <tr>
+              <td width="125.33333333333333" valign="top">
+                <span>F_MIN=0</span>
+              </td>
+              <td width="99.33333333333333" valign="top">
+                <span>fmin=0.0</span>
+              </td>
+              <td width="137.33333333333334" valign="top">
+                <span>f_min=0</span>
+              </td>
+              <td width="127.33333333333334" valign="top">
+                <span>lower_edge_hertz</span>
+              </td>
+            </tr>
+            <tr>
+              <td width="125.33333333333333" valign="top">
+                <p><span>F_MAX=</span><span>SAMPLE_RATE/2</span></p>
+              </td>
+              <td width="99.33333333333333" valign="top">
+                <span>fmax=sr/2</span>
+              </td>
+              <td width="137.33333333333334" valign="top">
+                <span>f_max=None</span>
+              </td>
+              <td width="127.33333333333334" valign="top">
+                <span>upper_edge_hertz</span>
+              </td>
+            </tr>
+            <tr>
+              <td width="125.33333333333333" valign="top">
+                <span>N_FREQS=N_FFT//2+1</span>
+              </td>
+              <td width="99.33333333333333" valign="top">
+                <span><span>-</span></span>
+              </td>
+              <td width="137.33333333333334" valign="top">
+                <span>n_freqs</span>
+              </td>
+              <td width="127.33333333333334" valign="top">
+                <span>num_spectrogram_bins</span>
+              </td>
+            </tr>
+            <tr>
+              <td
+                valign="top"
+                colspan="1"
+                rowspan="1"
+                width="124.33333333333331"
+              >
+                <span>N_MELS= 128</span>
+              </td>
+              <td
+                valign="top"
+                colspan="1"
+                rowspan="1"
+                width="99.33333333333333"
+              >
+                <span>n_mels=128</span>
+              </td>
+              <td
+                valign="top"
+                colspan="1"
+                rowspan="1"
+                width="137.33333333333334"
+              >
+                <span>n_mels=128</span>
+              </td>
+              <td
+                valign="top"
+                colspan="1"
+                rowspan="1"
+                width="127.33333333333334"
+              >
+                <pre><span>num_mel_bins</span></pre>
+              </td>
+            </tr>
+            <tr>
+              <td
+                valign="top"
+                colspan="1"
+                rowspan="1"
+                width="124.33333333333331"
+              >
+                <span>NORM=None</span>
+              </td>
+              <td
+                valign="top"
+                colspan="1"
+                rowspan="1"
+                width="99.33333333333333"
+              >
+                <span>norm='slaney'</span>
+              </td>
+              <td
+                valign="top"
+                colspan="1"
+                rowspan="1"
+                width="137.33333333333334"
+              >
+                <span>norm=None</span>
+              </td>
+              <td
+                valign="top"
+                colspan="1"
+                rowspan="1"
+                width="127.33333333333334"
+              >
+                <span>依赖HTK<br /></span>
+              </td>
+            </tr>
+            <tr>
+              <td
+                valign="top"
+                colspan="1"
+                rowspan="1"
+                width="124.33333333333331"
+              >
+                <span>MEL_SCALE='htk'</span>
+              </td>
+              <td
+                valign="top"
+                colspan="1"
+                rowspan="1"
+                width="99.33333333333333"
+              >
+                <span>htk=False</span>
+              </td>
+              <td
+                valign="top"
+                colspan="1"
+                rowspan="1"
+                width="137.33333333333334"
+              >
+                <span>mel_scale='htk'</span>
+              </td>
+              <td
+                valign="top"
+                colspan="1"
+                rowspan="1"
+                width="127.33333333333334"
+              >
+                <span>依赖HTK</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <p>
+          <span
+            >本文中用到的事例音频可从librosa下载，并只用其40秒到45秒之间重采样的片段数据。</span
+          >
+        </p>
+        <section>
+          <pre
+            data-lang="swift"
+          ><code><span><span>import</span> numpy as np</span></code><code><span><span>import</span> pandas as pd</span></code><code><span><span>import</span> librosa</span></code><code><span>from essentia.standard <span>import</span> *</span></code><code><span><span>import</span> torch, torchaudio</span></code><code><span><span>import</span>&nbsp;tensorflow&nbsp;as&nbsp;tf</span></code><code><span><br></span></code><code><span>filename = librosa.util.example_audio_file()</span></code><code><span>audio, <span>_</span> = librosa.load(filename, </span></code><code><span>                        sr=<span>SAMPLE_RATE</span>, mono=<span>MONO</span>, </span></code><code><span>                        offset=<span>OFFSET</span>, duration=<span>LOAD_DURATION</span>)</span></code></pre>
+        </section>
+        <hr />
+        <h3>『Spectrogram』</h3>
+        <p>
+          <span
+            >分别用四种不同的库，计算示例5秒音频片段的magnitue spectrogram和log
+            power spectrogram。<br
+          /></span>
+        </p>
+        <p>
+          <span
+            ><span></span><span>☞</span> 使用librosa得到的维度是1025 x 427：<br
+          /></span>
+        </p>
+        <section>
+          <pre
+            data-lang="properties"
+          ><code><span><span># magnitude spectrogram</span></span></code><code><span><span>spec_librosa</span> = <span>np.abs(librosa.stft(y=audio, </span></span></code><code><span>                                   <span>n_fft</span>=<span>N_FFT, </span></span></code><code><span>                                   <span>hop_length</span>=<span>HOP_LENGTH, </span></span></code><code><span>                                   <span>win_length</span>=<span>WIN_LENGTH,</span></span></code><code><span>                                   <span>window</span>=<span>WINDOW,</span></span></code><code><span><span>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;center</span>=<span>CENTER))</span></span></code><code><span><span># log power spectrogram</span></span></code><code><span><span>lpspec_librosa</span> = <span>librosa.power_to_db(spec_librosa ** 2)</span></span></code></pre>
+        </section>
+        <p>
+          <span
+            ><span>☞</span><span>&nbsp;</span>使用essentia<span
+              >得到的维度是427 x 1025</span
+            ><span>：</span></span
+          >
+        </p>
+        <section>
+          <pre
+            data-lang="makefile"
+          ><code><span><span># magnitude spectrogram</span></span></code><code><span>spec_essentia = []</span></code><code><span>es_win_func = Windowing(normalized=False, size=WIN_LENGTH, type='hann')</span></code><code><span>es_spec_func = FFT(size=N_FFT)</span></code><code><span>for frame in FrameGenerator(audio, frameSize=N_FFT, hopSize=HOP_LENGTH, </span></code><code><span>                            startFromZero=True, validFrameThresholdRatio=1.0, lastFrameToEndOfFile=False):</span></code><code><span>    spec_complex = es_spec_func(es_win_func(frame))</span></code><code><span>    spec_essentia.append(np.abs(spec_complex))  </span></code><code><span>spec_essentia&nbsp;=&nbsp;essentia.array(spec_essentia)</span></code><code><span><span># log power spectrogram</span></span></code><code><span>lpspec_essentia = librosa.power_to_db(spec_essentia ** 2)</span></code></pre>
+        </section>
+        <p>
+          <span></span
+          ><span
+            ><span>☞</span><span>&nbsp;</span>使用torchaudio<span
+              >得到的维度是1025 x 427</span
+            ><span>：</span></span
+          >
+        </p>
+        <section>
+          <pre
+            data-lang="properties"
+          ><code><span><span># magnitude spectrogram</span></span></code><code><span><span>spec_torch</span> = <span>torchaudio.transforms.Spectrogram(</span></span></code><code><span>    <span>n_fft</span>=<span>N_FFT,</span></span></code><code><span>    <span>win_length</span>=<span>WIN_LENGTH,</span></span></code><code><span>    <span>hop_length</span>=<span>HOP_LENGTH,</span></span></code><code><span>    <span>window_fn</span>=<span>torch.hann_window,</span></span></code><code><span>    <span>power</span>=<span>None,</span></span></code><code><span>    <span>center</span>=<span>CENTER,</span></span></code><code><span>    <span>return_complex</span>=<span>True</span></span></code><code><span><span>)(torch.Tensor(audio))</span></span></code><code><span><span>spec_torch</span> = <span>spec_torch.numpy()</span></span></code><code><span><span>spec_torch&nbsp;</span>=<span>&nbsp;np.abs(spec_torch)</span></span></code><code><span><span># log power spectrogram</span></span></code><code><span><span>lpspec_torch</span> = <span>librosa.power_to_db(spec_torch ** 2)</span></span></code></pre>
+        </section>
+        <p>
+          <span
+            ><span>☞</span><span>&nbsp;</span>使用tensorflow<span
+              >得到的维度是427 x 1025</span
+            ><span>：</span></span
+          ><br /><span></span>
+        </p>
+        <section>
+          <pre
+            data-lang="properties"
+          ><code><span><span># magnitude spectrogram</span></span></code><code><span><span>spec_tf</span> = <span>tf.abs(tf.signal.stft(</span></span></code><code><span>    <span>signals</span>=<span>tf.convert_to_tensor(audio, dtype=tf.float32),</span></span></code><code><span>    <span>frame_length</span>=<span>N_FFT,</span></span></code><code><span>    <span>frame_step</span>=<span>HOP_LENGTH,</span></span></code><code><span>    <span>fft_length</span>=<span>N_FFT,</span></span></code><code><span>    <span>window_fn</span>=<span>tf.signal.hann_window,</span></span></code><code><span>    <span>pad_end</span>=<span>PAD_END))</span></span></code><code><span><span>spec_tf&nbsp;</span>=<span>&nbsp;spec_tf.numpy()</span></span></code><code><span><span># log power spectrogram</span></span></code><code><span><span>lpspec_tf</span> = <span>librosa.power_to_db(spec_tf ** 2)</span></span></code></pre>
+        </section>
+        <p>
+          <span
+            >将以上代码得到的log power
+            spectrogram都画出来，也不会看到非常明显的不同。但是在数值上确实都是有区别的，区别的大小我们可以用Mean
+            Square Error (MSE)
+            衡量，值越大则区别越大。下方表格的区别从小到大排列，统一设定参数的情况下，librosa和torchaudio得出的<span
+              >log power spectrogram</span
+            >在数值上最为接近。</span
+          ><span></span>
+        </p>
+        <p><span></span></p>
+        <table>
+          <thead>
+            <tr>
+              <th><br /></th>
+              <th><span>kernel</span></th>
+              <th><span>compare_kernel</span></th>
+              <th><span>mse</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th><span>0</span></th>
+              <td><span>librosa</span></td>
+              <td><span>torchaudio</span></td>
+              <td><span>1.153476e-09</span></td>
+            </tr>
+            <tr>
+              <th><span>1</span></th>
+              <td><span>librosa</span></td>
+              <td><span>tensorflow</span></td>
+              <td><span>9.368608e-07</span></td>
+            </tr>
+            <tr>
+              <th><span>2</span></th>
+              <td><span>tensorflow</span></td>
+              <td><span>torchaudio</span></td>
+              <td><span>9.407697e-07</span></td>
+            </tr>
+            <tr>
+              <th><span>3</span></th>
+              <td><span>essentia</span></td>
+              <td><span>torchaudio</span></td>
+              <td><span>2.041789e-04</span></td>
+            </tr>
+            <tr>
+              <th><span>4</span></th>
+              <td><span>essentia</span></td>
+              <td><span>librosa</span></td>
+              <td><span>2.042010e-04</span></td>
+            </tr>
+            <tr>
+              <th><span>5</span></th>
+              <td><span>essentia</span></td>
+              <td><span>tensorflow</span></td>
+              <td><span>2.050108e-04</span></td>
+            </tr>
+          </tbody>
+        </table>
+        <hr />
+        <h3>『Mel Filter Bank』</h3>
+        <p>
+          <span
+            >鉴于上文中essentia与其他区别相对较大，之后我们主要检查其余三个python库之间的区别。为了得到melspectrogram，可将上文得到的"linear频带的spectrogram"与"可转换到mel尺度的矩阵"做矩阵乘法。所以这里我们先来看一下不同python库得到的linear
+            to mel matrix。</span
+          >
+        </p>
+        <p>
+          <span
+            ><span>☞</span><span> </span
+            ><span>使用librosa得到的维度是128 x 1025：</span></span
+          ><br />
+        </p>
+        <section>
+          <pre
+            data-lang="properties"
+          ><code><span><span>l2m_librosa</span> = <span>librosa.filters.mel(sr=SAMPLE_RATE, </span></span></code><code><span>                                  <span>n_fft</span>=<span>N_FFT, </span></span></code><code><span>                                  <span>n_mels</span>=<span>N_MELS, </span></span></code><code><span>                                  <span>fmin</span>=<span>F_MIN,</span></span></code><code><span>                                  <span>fmax</span>=<span>F_MAX, </span></span></code><code><span>                                  <span>htk</span>=<span>MEL_SCALE=='htk', </span></span></code><code><span>                                  <span>norm</span>=<span>NORM)</span></span></code></pre>
+        </section>
+        <p>
+          <span>☞</span><span> </span
+          ><span>使用torchaudio得到的维度是1025 x 128：</span>
+        </p>
+        <p>
+          <span><span></span></span>
+        </p>
+        <section>
+          <pre
+            data-lang="properties"
+          ><code><span><span>l2m_torch</span> = <span>torchaudio.functional.create_fb_matrix(</span></span></code><code><span>    <span>n_freqs</span>=<span>N_FREQS, </span></span></code><code><span>    <span>f_min</span>=<span>F_MIN, </span></span></code><code><span>    <span>f_max</span>=<span>F_MAX, </span></span></code><code><span>    <span>n_mels</span>=<span>N_MELS, </span></span></code><code><span>    <span>sample_rate</span>=<span>SAMPLE_RATE, </span></span></code><code><span>    <span>norm</span>=<span>NORM, </span></span></code><code><span>    <span>mel_scale</span>=<span>MEL_SCALE)</span></span></code></pre>
+        </section>
+        <p>
+          <span>☞</span><span> </span
+          ><span>使用tensorflow得到的维度是1025 x 128：</span><br />
+        </p>
+        <p>
+          <span><span></span></span>
+        </p>
+        <section>
+          <pre
+            data-lang="properties"
+          ><code><span><span>l2m_tf</span> = <span>tf.signal.linear_to_mel_weight_matrix(</span></span></code><code><span>    <span>num_mel_bins</span>=<span>N_MELS,</span></span></code><code><span>    <span>num_spectrogram_bins</span>=<span>N_FREQS,</span></span></code><code><span>    <span>sample_rate</span>=<span>SAMPLE_RATE,</span></span></code><code><span>    <span>lower_edge_hertz</span>=<span>F_MIN,</span></span></code><code><span>    <span>upper_edge_hertz</span>=<span>F_MAX)</span></span></code></pre>
+        </section>
+        <p>
+          <span
+            ><span
+              >以上三者之间的区别如下表所示，max_abs_diff表示，两两相减时得到的最大绝对差值。</span
+            ></span
+          >
+        </p>
+        <table>
+          <thead>
+            <tr>
+              <th><br /></th>
+              <th><span>kernel</span></th>
+              <th><span>compare_kernel</span></th>
+              <th><span>max_abs_diff</span></th>
+              <th><span>mse</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th><span>0</span></th>
+              <td><span>librosa</span></td>
+              <td><span>torchaudio</span></td>
+              <td><span>0.000011</span></td>
+              <td><span>2.611765e-13</span></td>
+            </tr>
+            <tr>
+              <th><span>1</span></th>
+              <td><span>librosa</span></td>
+              <td><span>tensorflow</span></td>
+              <td><span>0.003384</span></td>
+              <td><span>9.346046e-08</span></td>
+            </tr>
+            <tr>
+              <th><span>2</span></th>
+              <td><span>tensorflow</span></td>
+              <td><span>torchaudio</span></td>
+              <td><span>0.003392</span></td>
+              <td><span>9.356785e-08</span></td>
+            </tr>
+          </tbody>
+        </table>
+        <p>
+          <span>依然是<span>librosa和torchaudio之间差别最小。</span></span
+          ><br />
+        </p>
+        <hr />
+        <h3>『Mel Spectrogram』</h3>
+        <p>
+          <span
+            >最后得magnitude melspectrogram, power melspectrogram, log power
+            melspectrogram三者，可按以下代码运算。</span
+          >
+        </p>
+        <section>
+          <pre
+            data-lang="ini"
+          ><code><span><span># librosa</span></span></code><code><span><span>melspec_librosa</span> = np.dot(l2m_librosa, spec_librosa)</span></code><code><span><span>pmelspec_librosa</span> = np.dot(l2m_librosa, spec_librosa ** <span>2</span>)</span></code><code><span><span>lpmelspec_librosa</span> = librosa.power_to_db(pmelspec_librosa)</span></code><code><span><span># torchaudio</span></span></code><code><span><span>melspec_torch</span> = torch.matmul(torch.Tensor(spec_torch.T), l2m_torch).numpy().T</span></code><code><span><span>pmelspec_torch</span> = torch.matmul(torch.Tensor(spec_torch.T ** <span>2</span>), l2m_torch).numpy().T</span></code><code><span><span>lpmelspec_torch</span> = librosa.power_to_db(pmelspec_torch)</span></code><code><span><span># tensorflow</span></span></code><code><span><span>melspec_tf</span> = tf.tensordot(spec_tf, l2m_tf, <span>1</span>).numpy().T</span></code><code><span><span>pmelspec_tf</span> = tf.tensordot(spec_tf ** <span>2</span>, l2m_tf, <span>1</span>).numpy().T</span></code><code><span><span>lpmelspec_tf</span> = librosa.power_to_db(pmelspec_tf)</span></code></pre>
+        </section>
+        <p>
+          <span></span
+          ><span
+            >melspec_librosa和pmelspec_librosa，也可以直接通过librosa.feature.melspectrogram()输入audio或spec_librosa得到，需要注意其中相应power参数值的设定。</span
+          >
+        </p>
+        <p>
+          <span>同理，torchaudio中也有直接得melspectrogram的功能：</span><br />
+        </p>
+        <section>
+          <pre
+            data-lang="properties"
+          ><code><span><span>pmelspec_torch_by_audio</span> = <span>torchaudio.transforms.MelSpectrogram(</span></span></code><code><span>    <span>sample_rate</span>=<span>SAMPLE_RATE,</span></span></code><code><span>    <span>n_fft</span>=<span>N_FFT,</span></span></code><code><span>    <span>win_length</span>=<span>WIN_LENGTH,</span></span></code><code><span>    <span>hop_length</span>=<span>HOP_LENGTH,</span></span></code><code><span>    <span>f_min</span>=<span>F_MIN,</span></span></code><code><span>    <span>f_max</span>=<span>F_MAX,    </span></span></code><code><span>    <span>n_mels</span>=<span>N_MELS,</span></span></code><code><span>    <span>window_fn</span>=<span>torch.hann_window,</span></span></code><code><span>    <span>power</span>=<span>2.0,</span></span></code><code><span>    <span>normalized</span>=<span>False,</span></span></code><code><span>    <span>center</span>=<span>CENTER,</span></span></code><code><span>    <span>norm</span>=<span>NORM,</span></span></code><code><span>    <span>mel_scale</span>=<span>MEL_SCALE</span></span></code><code><span><span>)(torch.Tensor(audio))</span></span></code><code><span><span>pmelspec_torch_by_audio&nbsp;</span>=<span>&nbsp;pmelspec_torch_by_audio.numpy()</span></span></code><code><span><span>lpmelspec_torch_by_audio</span> = <span>librosa.power_to_db(pmelspec_torch_by_audio)</span></span></code></pre>
+        </section>
+        <p>
+          <span></span
+          ><span
+            >可是，目前我得到的pmelspec_torch_by_audio和前文中的pmelspec_torch，在数值上非常接近，但并非完全一致。<br
+          /></span>
+        </p>
+        <p>
+          <span>对以上log power melspectrogram之间的区别用MSE衡量可得：</span>
+        </p>
+        <table>
+          <thead>
+            <tr>
+              <th><br /></th>
+              <th><span>kernel</span></th>
+              <th><span>compare_kernel</span></th>
+              <th><span>mse</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th><span>0</span></th>
+              <td><span>librosa</span></td>
+              <td><span>torchaudio_l2m</span></td>
+              <td><span>7.132773e-10</span></td>
+            </tr>
+            <tr>
+              <th><span>1</span></th>
+              <td><span>librosa</span></td>
+              <td><span>torchaudio_direct</span></td>
+              <td><span>7.133121e-10</span></td>
+            </tr>
+            <tr>
+              <th><span>2</span></th>
+              <td><span>librosa</span></td>
+              <td><span>tensorflow</span></td>
+              <td><span>1.559776e-04</span></td>
+            </tr>
+            <tr>
+              <th><span>3</span></th>
+              <td><span>torchaudio_direct</span></td>
+              <td><span>torchaudio_l2m</span></td>
+              <td><span>1.416461e-13</span></td>
+            </tr>
+            <tr>
+              <th><span>4</span></th>
+              <td><span>tensorflow</span></td>
+              <td><span>torchaudio_l2m</span></td>
+              <td><span>1.560096e-04</span></td>
+            </tr>
+            <tr>
+              <th><span>5</span></th>
+              <td><span>tensorflow</span></td>
+              <td><span>torchaudio_direct</span></td>
+              <td><span>1.560096e-04</span></td>
+            </tr>
+          </tbody>
+        </table>
+        <p>
+          <span
+            >画出最小 (librosa vs. torchaudio_l2m) 和最大 (tensorflow vs.
+            torchaudio_direct) 对应在log power melspectrogram上的差值：</span
+          >
+        </p>
+        <p>
+          <img
+            data-original-style=""
+            data-index="2"
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJUVibuvlssc1WDQyMTOmfdEQuelKogaRwNsoicqcdlriaUdaR6AJiacgwDalm6gpNsmyyWGavL6L5jEIg/640"
+            _width="677px"
+            alt="Image"
+          />
+        </p>
+        <p><br /></p>
+        <hr />
+        <p>
+          <span
+            >目前来看，librosa (0.8.0版本) 和torchaudio (0.9.0版本)
+            在参数设置相互对齐的前提下，可以得到数值上相对接近的音频预处理结果。最后强调一些引起数值差别的主要参数：</span
+          >
+        </p>
+        <ul>
+          <li>
+            <p>
+              <span
+                >加窗时即使都使用'hann'，但不同库的窗函数仍在数值上有细微差别;<br
+              /></span>
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >分帧时是否居中 (center)，若采用居中则还需注意数据填充的模式
+                (pad_mode);</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >设置mel尺度时，根据HTK还是Slaney公式
+                (mel_scale)，另外要注意对mel权重的归一化方式 (norm)。</span
+              >
+            </p>
+          </li>
+        </ul>
+        <section>
+          <strong><span>相关文章回顾：</span></strong
+          ><a
+            target="_blank"
+            href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483684&amp;idx=1&amp;sn=d3f3746a6837f7d12044d1931cfd4ead&amp;chksm=fe0d9f8bc97a169dbfcb80443e8da87d8e35ae643bae76841060442d8f88a4f292cda594afa5&amp;scene=21#wechat_redirect"
+            data-itemshowtype="0"
+            tab="innerlink"
+            data-linktype="2"
+            >「MIR-01」要把音乐画出来，总共分几步？</a
+          ><br />
+        </section>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/bela-everyday-objects.html
+++ b/articles/bela-everyday-objects.html
@@ -1,0 +1,368 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>
+      「NIME-02」日常物件在没有成精的前提下如何发声儿？ - 无痛入门音乐科技
+    </title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「NIME-02」日常物件在没有成精的前提下如何发声儿？</h1>
+      <div class="meta">无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            软硬件兼备，创意点足够，把身边的物件儿变成声音装置绝非难事，“好想让生活自带背景音乐”貌似也不是什么问题了呢ಠ_ಠ
+          </p>
+        </blockquote>
+        <p>
+          <span><strong>♬ 本文为NIME系列第2篇文章，小视频为主 ♬</strong></span>
+        </p>
+        <p><span>不用怀疑自己的眼神儿，以下内容你将看到：</span></p>
+        <ul>
+          <li>
+            <p><span>墨水也能变成声音的控制器</span></p>
+          </li>
+          <li>
+            <p><span>针线织成的地图竟然能发声</span></p>
+          </li>
+          <li>
+            <p><span>敲击瓷砖怎么听见了编钟声</span></p>
+          </li>
+          <li>
+            <p><span>吊灯等日常物件摇身一变成了声音艺术装置</span></p>
+          </li>
+        </ul>
+        <hr />
+        <h3>『纸墨发声器』</h3>
+        <p>
+          <span
+            ><br />➥
+            <a
+              href="https://blog.bela.io/2018/04/13/conductive-ink-synthesiser-paper-circuits/"
+              target="_blank"
+              rel="noopener"
+              >https://blog.bela.io/2018/04/13/conductive-ink-synthesiser-paper-circuits/</a
+            ></span
+          >
+        </p>
+        <p>☞ 作者Nicolas Lewis</p>
+        <p>
+          这个装置的特殊之处在于可导电墨水（Bare Conductive's Electric
+          Paint）的应用，由这种墨水画出的线条加上可移动的导线就得到了一块简单的电位计，因此能连续地改变输出电压。视频里的两条墨水痕迹可输出两种变化电压，分别对应声音的音量大小和音符高低。至于声音听起来为什么这么像特雷门琴，是因为在Pure
+          Data里提前设定好的音色就是简单的正弦波。
+        </p>
+        <hr />
+        <h3>『可听的编织地图』</h3>
+        <p>
+          <span
+            ><br />➥
+            <a
+              href="https://blog.bela.io/2017/01/18/auralfabric/"
+              target="_blank"
+              rel="noopener"
+              >https://blog.bela.io/2017/01/18/auralfabric/</a
+            ></span
+          >
+        </p>
+        <p>☞ 作者Alessia Milo</p>
+        <p>
+          可穿戴技术能在时尚界一展拳脚，少不了这种导电纺织材料的功劳。而这种材料织成的地图与电容传感器一组合，就能知道用户在触摸地图上的哪块儿位置，从而播放该位置的实地录音。不得不说，这也是增强人们对“建筑物与其声音环境之间关系”的认知的一种新方式，在应用方面也能发展成适用于视障人士的特殊地图。
+        </p>
+        <hr />
+        <h3>『瓷砖打击乐器』</h3>
+        <p>
+          <img
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJXaR0WTapTvQxvhJg3pO4Ania4BMDBdW9nr2AicWmv9scUga5dt9DJPSW8m6OicMu6c5krbfTrKLsiaRg/640"
+          />
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://blog.bela.io/2017/01/11/percussion/"
+              target="_blank"
+              rel="noopener"
+              >https://blog.bela.io/2017/01/11/percussion/</a
+            ></span
+          ><br />
+        </p>
+        <p>☞ 作者Robert Jack</p>
+        <p>
+          相比于其他例子里自带导电属性的材料，瓷砖可是非常称职的绝缘材料，所以家家户户都用瓷砖装饰卫生间避免一边洗漱一边过电。这里的瓷砖之所以能感知敲击的时刻，是因为其背后附着压电传感器，敲击时引起的压力变化产生电压突变，就触发了声音的播放。
+        </p>
+        <p>
+          输出到底是编钟声还是其他杂七杂八的声音都可以自定义，主要的难点在于“如何快速回应敲击动作”，毕竟人耳很敏感，如果敲击发生了20毫秒以上才听到被触发的声音，所有人都会觉得“卡”，而延迟又是无法避免的，因此我们需要专用的“传感器信号➣声音信号”处理器来尽可能的控制延迟，本文里所有例子都用到了可将延迟缩短至2毫秒的开源平台Bela，在文章最后有介绍。
+        </p>
+        <hr />
+        <h3>『声音吊灯』</h3>
+        <p>
+          <img
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJXaR0WTapTvQxvhJg3pO4AnJuYX7fq3esxFEdH9QjoP9BoX8YmoeE0DOtVN38ysianlVDUVwo4vXIw/640"
+          />
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://blog.bela.io/2018/03/08/chandelia-lia-mice-bela/"
+              target="_blank"
+              rel="noopener"
+              >https://blog.bela.io/2018/03/08/chandelia-lia-mice-bela/</a
+            ></span
+          ><br />
+        </p>
+        <p>☞ 作者Lia Mice</p>
+        <p>
+          本身就和电密切相关，再加上额外传感器的助攻，吊灯就可以不仅仅是吊灯，还能变成一种电声乐器。敲击吊灯既可以改变亮度也能激发声音，如果继续摆弄吊灯就能改变方向传感器的输出，以此来控制当前声音的音效，比如加一些delay或chorus的效果。
+        </p>
+        <hr />
+        <h3>『声音艺术装置』</h3>
+        <p>
+          <img
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJXaR0WTapTvQxvhJg3pO4AnySwEPpx10JKISe8O1r6K3MdXaW4MksgTnMqrhuwKCGJUGH3Y3gG8bg/640"
+          />
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="http://www.feddetenberge.nl/sound-art-works"
+              target="_blank"
+              rel="noopener"
+              >http://www.feddetenberge.nl/sound-art-works</a
+            ></span
+          ><br />
+        </p>
+        <p>☞ 作者Fedde ten Berge</p>
+        <p>
+          这位荷兰艺术家可谓把简单的物品变成声音艺术装置发挥到了极致，传感器的选择与精细的声音设计，让人不得不觉得他手里的物件如果会发声，那注定就是这个声音。也许正因为如此，他与陶艺家Frank
+          van Os合作设计的一系列声音装置就叫做“Of Nature and
+          Things”，上图为系列中的作品之一de Stronk。
+        </p>
+        <hr />
+        <h3>『如果你也想做个乐器』</h3>
+        <p>看了这么多例子，总结一下DIY乐器的套路：</p>
+        <ul>
+          <li>
+            <p>
+              <span
+                >选择合适的传感器，如压敏、光敏、速度/加速度、距离、电容式触摸感应等等。</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >手里有开源的单片机开发平台，如Arduino、Raspberry Pi、
+                BeagleBone等等，来读取传感器信号。</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >本文例子中都用到的Bela平台基于BeagleBone，它由我们C4DM科研组的Augmented
+                Instrument
+                Lab开发，对音频处理做了许多优化，具体介绍可观看下方视频。</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >设计传感器信号与声音参数之间的映射，比如距离大小调整音量、速度快慢对应音高等等。</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >音色可以通过Pure Data、 SuperCollider、
+                Max/MSP等软件设计。</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >将以上映射关系和音色设计编程写入开发平台，再给平台连上一个声音功放，大功告成！</span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>☟ Bela介绍视频</p>
+        <p><br /></p>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/c4dm-icassp2019.html
+++ b/articles/c4dm-icassp2019.html
@@ -1,0 +1,330 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>「INFO」C4DM在ICASSP 2019的收录成果 - 无痛入门音乐科技</title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「INFO」C4DM在ICASSP 2019的收录成果</h1>
+      <div class="meta">无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            ICASSP（International Conference on Acoustics, Speech and Signal
+            Processing）即国际声学、语音与信号处理会议，是IEEE（电子技术与信息科学工程师协会）旗下在信号处理及其应用方面的顶级会议之一。
+          </p>
+        </blockquote>
+        <p>
+          今年的ICASSP会议将在5月12号至17号在英国的海滨城市布莱顿举行，大约从近3700篇投稿中接受了1700篇左右的文章，其中有以下10篇音乐音频方面的文章由博主所在C4DM科研组（Centre
+          for Digital Music, Queen Mary University of
+          London）的成员主笔或参与研究（按会议上展示时间的先后排序）。
+        </p>
+        <p><strong>✎ Paper: 1519</strong></p>
+        <p>
+          <em>Session</em>: AASP-P1: Acoustic Environments and Music Analysis<br />
+          <em>Location</em>: Poster Area D<br />
+          <em>Time</em>: Tuesday, May 14, 13:30 - 15:30<br />
+          <em>Presentation</em>: Poster<br />
+          <em>Topic</em>: Audio and Acoustic Signal Processing: Music Signal
+          Analysis, Processing and Synthesis<br />
+          <em>Title</em>: Piano Sustain-pedal Detection Using Convolutional
+          Neural Networks<br />
+          <em>Authors</em>: Beici Liang (博主本主😄), György Fazekas, Mark
+          Sandler
+        </p>
+        <p><strong>✎ Paper: 2497</strong></p>
+        <p>
+          <em>Session</em>: AASP-P1: Acoustic Environments and Music Analysis<br />
+          <em>Location</em>: Poster Area D<br />
+          <em>Time</em>: Tuesday, May 14, 13:30 - 15:30<br />
+          <em>Presentation</em>: Poster<br />
+          <em>Topic</em>: Audio and Acoustic Signal Processing: Music Signal
+          Analysis, Processing and Synthesis<br />
+          <em>Title</em>: Automatic Transcription Of Diatonic Harmonica
+          Recordings<br />
+          <em>Authors</em>: Filipe Lins, Marcelo Johann, Emmanouil Benetos,
+          Rodrigo Schramm
+        </p>
+        <p><strong>✎ Paper: 3676</strong></p>
+        <p>
+          <em>Session</em>: MLSP-P8: Probabilistic Models<br />
+          <em>Location</em>: Poster Area H<br />
+          <em>Time</em>: Wednesday, May 15, 13:30 - 15:30<br />
+          <em>Presentation</em>: Poster<br />
+          <em>Topic</em>: Machine Learning for Signal Processing: Bayesian
+          Learning and Modeling<br />
+          <em>Title</em>: Unifying Probabilistic Models For Time-frequency
+          Analysis<br />
+          <em>Authors</em>: William Wilkinson, Michael Riis Andersen, Joshua
+          Reiss, Dan Stowell, Arno Solin
+        </p>
+        <p><strong>✎ Paper: 2429</strong></p>
+        <p>
+          <em>Session</em>: AASP-L6: Music Signal Analysis, Processing and
+          Synthesis<br />
+          <em>Location</em>: Lecture Room 3<br />
+          <em>Time</em>: Thursday, May 16, 09:20 - 09:40 (Approximate)<br />
+          <em>Presentation</em>: Lecture<br />
+          <em>Topic</em>: Audio and Acoustic Signal Processing: Music Signal
+          Analysis, Processing and Synthesis<br />
+          <em>Title</em>: Modeling Nonlinear Audio Effects With End-to-end Deep
+          Neural Networks<br />
+          <em>Authors</em>: Marco A. Martinez Ramirez, Joshua D. Reiss
+        </p>
+        <p><strong>✎ Paper: 4852</strong></p>
+        <p>
+          <em>Session</em>: AASP-L7: Music Information Retrieval<br />
+          <em>Location</em>: Lecture Room 3<br />
+          <em>Time</em>: Thursday, May 16, 13:00 - 13:20 (Approximate)<br />
+          <em>Presentation</em>: Lecture<br />
+          <em>Topic</em>: Audio and Acoustic Signal Processing: Music
+          Information Retrieval and Music Language Processing<br />
+          <em>Title</em>: End-to-end Lyrics Alignment For Polyphonic Music Using
+          An Audio-to-Character Recognition Model<br />
+          <em>Authors</em>: Daniel Stoller, Simon Durand, Sebastian Ewert
+        </p>
+        <p><strong>✎ Paper: 3618</strong></p>
+        <p>
+          <em>Session</em>: AASP-P13: Acoustic Scene Classification and Music
+          Signal Analysis<br />
+          <em>Location</em>: Poster Area D<br />
+          <em>Time</em>: Thursday, May 16, 18:00 - 20:00<br />
+          <em>Presentation</em>: Poster<br />
+          <em>Topic</em>: Audio and Acoustic Signal Processing: Detection and
+          Classification of Acoustic Scenes and Events<br />
+          <em>Title</em>: Subspectralnet - Using Sub-spectrogram Based
+          Convolutional Neural Networks For Acoustic Scene Classification<br />
+          <em>Authors</em>: Sai Samarth R Phaye, Emmanouil Benetos, Ye Wang
+        </p>
+        <p><strong>✎ Paper: 3995</strong></p>
+        <p>
+          <em>Session</em>: AASP-P13: Acoustic Scene Classification and Music
+          Signal Analysis<br />
+          <em>Location</em>: Poster Area D<br />
+          <em>Time</em>: Thursday, May 16, 18:00 - 20:00<br />
+          <em>Presentation</em>: Poster<br />
+          <em>Topic</em>: Audio and Acoustic Signal Processing: Music Signal
+          Analysis, Processing and Synthesis<br />
+          <em>Title</em>: Comparing CQT And Reassignment Based Chroma Features
+          For Template-based Automatic Chord Recognition<br />
+          <em>Authors</em>: Ken O'Hanlon, Mark Sandler
+        </p>
+        <p><strong>✎ Paper: 3331</strong></p>
+        <p>
+          <em>Session</em>: AASP-P15: Spatial Audio Recording and Detection and
+          Classification of Acoustic Scenes and Events<br />
+          <em>Location</em>: Poster Area D<br />
+          <em>Time</em>: Friday, May 17, 13:30 - 15:30<br />
+          <em>Presentation</em>: Poster<br />
+          <em>Topic</em>: Audio and Acoustic Signal Processing: Detection and
+          Classification of Acoustic Scenes and Events<br />
+          <em>Title</em>: Sound-based Transportation Mode Recognition With
+          Smartphones<br />
+          <em>Authors</em>: Lin Wang, Daniel Roggen
+        </p>
+        <p><strong>✎ Paper: 4087</strong></p>
+        <p>
+          <em>Session</em>: SS-L18: Wildlife Bioacoustics and Adaptive Signal
+          Processing<br />
+          <em>Location</em>: Lecture Room 3<br />
+          <em>Time</em>: Friday, May 17, 15:10 - 15:30 (Approximate)<br />
+          <em>Presentation</em>: Lecture<br />
+          <em>Topic</em>: Special Sessions: Wildlife Bioacoustics and Adaptive
+          Signal Processing<br />
+          <em>Title</em>: Audio-based Identification Of Beehive States<br />
+          <em>Authors</em>: Inês Nolasco, Alessandro Terenzi, Stefania Cecchi,
+          Simone Orcioni, Helen L. Bear, Emmanouil Benetos
+        </p>
+        <p><strong>✎ Paper: 4423</strong></p>
+        <p>
+          <em>Session</em>: AASP-P16: Music Signal Analysis, Feedback and Echo
+          Cancellation and Equalization<br />
+          <em>Location</em>: Poster Area D<br />
+          <em>Time</em>: Friday, May 17, 16:00 - 18:00<br />
+          <em>Presentation</em>: Poster<br />
+          <em>Topic</em>: Audio and Acoustic Signal Processing: Music Signal
+          Analysis, Processing and Synthesis<br />
+          <em>Title</em>: Sparse Gaussian Process Audio Source Separation Using
+          Spectrum Priors In The Time-domain<br />
+          <em>Authors</em>: Pablo A. Alvarado, Mauricio A. Álvarez, Dan Stowell
+        </p>
+        <p>
+          另外Dan Stowell老师将与Naomi Harte和Theo Damoulas共同主持Special
+          Session on Adaptive Signal Processing for Wildlife
+          Bioacoustics。同时也祝贺C4DM曾经的组友Qiuqiang Kong（现University of
+          Surrey, CVSSP博士生）和Shengchen
+          Li（现北京邮电大学教师）的文章被收录，布莱顿见啦！
+        </p>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/c4dm-phd.html
+++ b/articles/c4dm-phd.html
@@ -1,0 +1,452 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>「INFO」在C4DM读博是怎样一番体验？ - 无痛入门音乐科技</title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「INFO」在C4DM读博是怎样一番体验？</h1>
+      <div class="meta">无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote><p>博主从2014年9月至今的五年读博小经历</p></blockquote>
+        <p>
+          还在关注这个公众号的各位朋友，博主大声地给大家问个好：嗨！！！我在7月初终于提交了博士毕业论文，接着跟全家开心地游玩了一圈儿之后，终于又回到这里更新了！
+        </p>
+        <p>
+          话说这些年来，博主收到最多的私信问题就是关于C4DM的硕士或博士项目申请，所以在继续更新技术文章之前，想用这篇横跨五年的流水账简单过个渡，大致讲一讲：
+        </p>
+        <ul>
+          <li>
+            <p>
+              <span><span>大学期间的准备和申请</span><span></span></span>
+            </p>
+          </li>
+          <li>
+            <p>
+              <span><span>第一年的课程培训和企业实习</span><span></span></span>
+            </p>
+          </li>
+          <li>
+            <p>
+              <span><span>接下来三年的科研学术</span><span></span></span>
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><span>最后一年的收尾安排</span><strong><span></span></strong
+              ></span>
+            </p>
+          </li>
+        </ul>
+        <hr />
+        <h3>『准备与申请』</h3>
+        <p>
+          和准备留学的国内大学生一样，大三的时候就把英语相关的考试都搞定，大四一开学就能开始投递申请材料了。申请博士项目最好先和外方导师邮件沟通一下，搞清楚导师目前主要研究的方向，有无招新博士的名额等等。
+        </p>
+        <p>C4DM目前招收博士有主要是两大渠道：</p>
+        <ol>
+          <li>
+            <p>
+              <span
+                >通过EECS即电子信息工程与计算机学院的常规化博士申请（四年学制）</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >通过C4DM教职工负责的Media &amp; Arts Technology (MAT)
+                或者Artificial Intelligence and Music (AIM)
+                任意一个博士培养项目申请（五年学制）</span
+              >
+            </p>
+          </li>
+        </ol>
+        <p>具体申请过程建议仔细阅读：</p>
+        <p>
+          <span
+            >➥
+            <a
+              href="http://eecs.qmul.ac.uk/phd/how-to-apply/"
+              target="_blank"
+              rel="noopener"
+              >http://eecs.qmul.ac.uk/phd/how-to-apply/</a
+            ></span
+          >
+        </p>
+        <p>
+          材料递交后会进行第一轮筛选，通过的申请者会被邀请面试，面试人很大可能就是将来的大导师和二导师，最后成功的申请人会收到offer，里面会写明是否免学费是否有奖学金等等。
+        </p>
+        <p>
+          因为大部分英国奖学金在授予优先级上先照顾英国本土学生，再之后是欧盟学生，最最后是其他国际学生，所以博主认识的大部分中国学生都是通过CSC即“国家建设高水平大学公派研究生项目”的奖学金来读博的。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://www.csc.edu.cn/chuguo"
+              target="_blank"
+              rel="noopener"
+              >https://www.csc.edu.cn/chuguo</a
+            ></span
+          >
+        </p>
+        <p>
+          针对于”这个难不难申请“之类的问题，因为每个人的情况都不一样，所以这个真没法回答。
+        </p>
+        <p>
+          ☞ 以博主在大四期间申请MAT博士项目和CSC奖学金的时间节点为例，总结来说：
+        </p>
+        <ul>
+          <li>
+            <p><span>2013年8月，考完托福</span></p>
+          </li>
+          <li>
+            <p><span>2013年9月，准备好所有文书材料</span></p>
+          </li>
+          <li>
+            <p><span>2013年10月，联系外方导师</span></p>
+          </li>
+          <li>
+            <p><span>2013年11月，提交申请材料</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                >2013年12月13日，面试(当时导师给了个口头offer，并建议申请CSC奖学金)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >2014年3月6日，收到QMUL学校正式开具的有条件录取offer(申请者在出具本科毕业证、学位证、成绩单之后才能被正式录取)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >2014年3-4月，天津大学开始收取CSC奖学金申报材料，统一向国家留学基金委申报</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>2014年5月，获得CSC奖学金</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                >2014年7月，本科毕业，将毕业材料再发回给QMUL，这样才能被正式录取，并拿到CAS用于英国学生签证的申请</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >2014年9月15日，人到伦敦，成为一名“由QMUL免除学费，CSC提供生活费，MAT项目提供科研和差旅经费”的博士研究生。</span
+              >
+            </p>
+          </li>
+        </ul>
+        <hr />
+        <h3>『第一年的课程』</h3>
+        <p>
+          博主当年申请时，只有MAT这一个博士项目，19年开始才有了专攻音乐科技的AIM项目。相比于EECS常规博士来了就要开始投入科研，MAT和AIM会有一年类似硕士培养的过渡阶段，非常适合我这样没有什么科研经历、还是从其他专业跨进来的本科愣头青。
+        </p>
+        <p>
+          一年的课程里分三个学期，前两个学期里每学期三门课，第三学期就是考试，其中从4月到9月小半年时间里，还要和校外企业/组织合作一个项目，类似实习。最后通过六门课的成绩、项目报告、项目校内外两次展演，决定学生是否有能力继续读博。
+        </p>
+        <p>
+          当时14/15学年的六门课程里有四门必修（交互数字媒体技术，录音与声音制作，纪录片制作、研究方法导论）和两门选修，之后的两年里还要再选三门课。音乐相关的课程有数字信号处理、音乐与语音信号建模、音乐音效设计、音乐认知等等，当然也可以选很多计算机和数据科学的课程，只要时间不冲突就好。
+        </p>
+        <p>
+          我修过的课程基本都是以作业为主、最后考试成绩为辅，所以第一年的时候感觉自己每天都在写作业…反倒是最后企业实习阶段稍微轻松一点:)
+        </p>
+        <p>☞ 关于MAT博士项目详情：</p>
+        <p>
+          <span
+            >➥
+            <a href="http://www.mat.qmul.ac.uk/" target="_blank" rel="noopener"
+              >http://www.mat.qmul.ac.uk/</a
+            ></span
+          >
+        </p>
+        <p>☞ 关于AIM博士项目详情：</p>
+        <p>
+          <span
+            >➥
+            <a href="https://www.aim.qmul.ac.uk/" target="_blank" rel="noopener"
+              >https://www.aim.qmul.ac.uk/</a
+            ></span
+          >
+        </p>
+        <hr />
+        <h3>『三年的纯科研』</h3>
+        <p>
+          从15年9月到18年9月，“整整三年只研究一件事儿”的经历真的是太难忘了。除了每周和大导师开大组会、和小导师开一对一小会，就是写代码、跑实验、总结数据、发论文、参加会议这样周而复始，好在伦敦是个很难让人无聊的城市，除了吃中餐性价比太低，真的没什么毛病……
+        </p>
+        <p>
+          在C4DM读博，主要围绕几个关键的时间节点，这儿叫“stage"。科研的头三个月就要开题，过stage
+          0。接下来的半年要做好充分的文献回顾，过stage
+          1。再之后一年左右的时间里要完成大部分的实验，过stage
+          2。如果三年下来还不能正式开始写毕业论文，就要再过一个stage 3。
+        </p>
+        <p>
+          每次stage的审核除了要交报告，还要面对大导师、二导师、独立审查人做阶段汇报。没通过审核，那这个阶段就得再来一遍了……虽然英国这边大多对博士的论文发表情况没有硬性要求，但论文多一些能保证stage的通过。
+        </p>
+        <p>
+          ☞ 查看相关往期文章 -
+          <a
+            href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483761&amp;idx=1&amp;sn=52b81b9fca161df1afad2a8babad251a&amp;chksm=fe0d9fdec97a16c8d41ca5c17d557ed2cee995782d486f91d662ad4abc5cf8315718a264921f&amp;scene=21#wechat_redirect"
+            target="_blank"
+            data-itemshowtype="0"
+            data-linktype="2"
+            >音乐科技相关会议期刊列表</a
+          >
+        </p>
+        <hr />
+        <h3>『最后一年的收尾』</h3>
+        <p>
+          博士第五年开始的头一件事就是transfer to write-up
+          stage，这时基本对毕业论文里要写什么心里有八成把握。除了特殊情况，学校要求博士生在一年内必须交论文。
+        </p>
+        <p>
+          每天都按计划写作的人，效率高的话两个月就能写好。像我这样还在改改实验发发论文飞飞会议，中途还回家过个年的，就写了半年多才完事儿，之后再和大导师二导师来回改改改，终于在2019年最最中间的7月2号把200页的毕业论文交了上去。
+        </p>
+        <p>
+          <img
+            src="https://mmbiz.qpic.cn/mmbiz_jpg/7CrMia15fFJX9ia6b5q7ibhlCYD7NrIJxzhMpHAt94ibnvV0CL6S9EYsySedfwXd9cyNU5ASNd5t9XiaoOGPVXGS2Gw/640"
+          />
+        </p>
+        <p><span>当时交完论文立马修图各处发状态</span><span></span></p>
+        <p>最后，为了拿到博士证书，还有一段考验耐心的流程：<br /></p>
+        <ul>
+          <li>
+            <p>
+              <span
+                >提交毕业论文前3个月，大导师需要确定答辩委员会人选，一般为两人，分别来自校内校外，且不能与博士生或者导师有任何利益纠葛。</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >提交毕业论文后，答辩委员会老师要精读两个月左右，期间会与大导师确认博士生的答辩日期（博主现在就在这个阶段）。</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >答辩当天，两位老师向博士生逐页发问，整个过程大致3-5个小时。</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >根据毕业论文质量和答辩的表现，判定博士生不需要改动、需要小改、需要大改、重写毕业论文。</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >大多需要小改的博士生，要在三个月内根据审核意见改完毕业论文。</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >将改好的毕业论文再次由答辩委员会老师以及校方学术委员会进行审核，没有问题后会颁发一个类似于学位证的award
+                email</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>最最后才能拿到纸质的博士学位证！</span></p>
+          </li>
+        </ul>
+        <hr />
+        <p>
+          经历了这一切，拿到博士头衔，其实才刚刚成为一名有独立学术能力的科研人员。继续坚定地留在学术界教书育人搞研究的人，博主由衷佩服。
+        </p>
+        <p>
+          在新一年度的申请季里，祝愿每一位申请人都能如愿以偿申到最理想的学校呀！
+        </p>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/claude-code-mir.html
+++ b/articles/claude-code-mir.html
@@ -1,0 +1,553 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>
+      「MIR-CC」2026年用Claude Code就可以无痛入门音乐科技 - 无痛入门音乐科技
+    </title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「MIR-CC」2026年用Claude Code就可以无痛入门音乐科技</h1>
+      <div class="meta">2026年2月14日 17:53 · 无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            <span leaf=""
+              >自从2025年末Claude Opus
+              4.5模型发布后，博主就再也没写过代码了，每天都在和agents对话，只需要开发不同的plugins和bots做自动化。现沉迷在前不久发布的4.6中，让这个公众号时隔3年发篇新的科普文章！</span
+            >
+          </p>
+        </blockquote>
+        <section>
+          <span
+            ><strong
+              ><span leaf=""
+                >♬ 本文为MIR音乐信息检索系列的第14篇文章 ♬</span
+              ></strong
+            ></span
+          >
+        </section>
+        <section>
+          <span
+            ><span leaf=""
+              >本文将展示在Claude Code (以下简称CC) 的作用下，</span
+            ></span
+          ><span
+            ><span leaf="">该公众号在GitHub上的代码仓库</span
+            ><span
+              leaf=""
+              data-pm-slice='1 1 ["para",{"tagName":"section","attributes":{"style":"margin-top: 15px;margin-bottom: 15px;box-sizing: border-box;font-size: 16px;white-space: pre-line;color: rgb(74, 74, 74);font-family: Avenir, -apple-system-font, 微软雅黑, sans-serif;line-height: 1.5em;"},"namespaceURI":"http://www.w3.org/1999/xhtml"},"node",{"tagName":"span","attributes":{"style":"font-size: 14px;"},"namespaceURI":"http://www.w3.org/1999/xhtml"}]'
+              ><span textstyle="">intro2musictech</span>做了哪些更新</span
+            ><span leaf="">：</span></span
+          >
+        </section>
+        <ul>
+          <li>
+            <section>
+              <span leaf="">迁移到uv包管理器，告别繁琐的conda/pip环境配置</span>
+            </section>
+          </li>
+          <li>
+            <section>
+              <span leaf="">修复过时的指引，确保在Python 3.12下运行</span>
+            </section>
+          </li>
+          <li>
+            <section>
+              <span leaf=""
+                >新增marimo交互式notebook，模拟与CC结对编程学习MIR的体验</span
+              ><span leaf=""><br /></span>
+            </section>
+          </li>
+          <li>
+            <section>
+              <span leaf=""
+                >将notebook导出为静态HTML并部署到GitHub
+                Pages，读者无需本地安装即可在线浏览：<a
+                  href="https://beiciliang.github.io/intro2musictech/"
+                  target="_blank"
+                  rel="noopener"
+                  >https://beiciliang.github.io/intro2musictech/</a
+                ></span
+              >
+            </section>
+          </li>
+        </ul>
+        <hr />
+        <h3><span leaf="">『环境配置现代化』</span></h3>
+        <p>
+          <span leaf=""
+            >过去，读者需要先安装Anaconda，再创建conda虚拟环境，再用pip安装依赖。步骤多、容易出错，尤其对零编程基础的读者来说是一道不小的门槛。现在项目全面迁移到uv包管理器：</span
+          >
+        </p>
+        <ul>
+          <li>
+            <p>
+              <span leaf=""
+                >新建pyproject.toml统一管理项目元数据和依赖版本（numpy&gt;=1.22、librosa&gt;=0.10
+                等），并补充了之前缺失的依赖</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                leaf=""
+                data-pm-slice='1 1 ["para",{"tagName":"p","attributes":{"style":"margin-top: 15px; margin-bottom: 15px; box-sizing: border-box; font-size: 16px; white-space: pre-line; line-height: 30px; color: rgb(74, 74, 74); font-family: Avenir, -apple-system-font, 微软雅黑, sans-serif;"},"namespaceURI":"http://www.w3.org/1999/xhtml"}]'
+                >删除了旧的requirements.txt，</span
+              ><span leaf=""
+                >生成uv.lock锁定文件，确保所有读者安装到完全一致的版本，彻底告别「我这里跑不通」的问题</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span leaf=""
+                >设置Python最低版本为3.10，支持最新的Python 3.12</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span leaf=""
+                >只需uv
+                sync一条命令，uv会自动下载合适的Python版本并安装全部依赖</span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>
+          <span
+            leaf=""
+            data-pm-slice='1 1 ["para",{"tagName":"p","attributes":{"style":"margin-top: 15px; margin-bottom: 15px; box-sizing: border-box; font-size: 16px; white-space: pre-line; line-height: 30px; color: rgb(74, 74, 74); font-family: Avenir, -apple-system-font, 微软雅黑, sans-serif;"},"namespaceURI":"http://www.w3.org/1999/xhtml"}]'
+            >另外，修复了所有notebook使其不再调用过时的API，还美化了README页面。</span
+          >
+        </p>
+        <p>
+          <span
+            leaf=""
+            data-pm-slice='1 1 ["para",{"tagName":"p","attributes":{"style":"margin-top: 15px; margin-bottom: 15px; box-sizing: border-box; font-size: 16px; white-space: pre-line; line-height: 30px; color: rgb(74, 74, 74); font-family: Avenir, -apple-system-font, 微软雅黑, sans-serif;"},"namespaceURI":"http://www.w3.org/1999/xhtml"}]'
+            >以上所有更新修复，在CC理解了该项目后（首次接触可使用 /init
+            指令生成CLAUDE.md文件），大概不到10分钟就能完成 ✅&nbsp;</span
+          >
+        </p>
+        <p>
+          <span
+            leaf=""
+            data-pm-slice='1 1 ["para",{"tagName":"p","attributes":{"style":"margin-top: 15px; margin-bottom: 15px; box-sizing: border-box; font-size: 16px; white-space: pre-line; line-height: 30px; color: rgb(74, 74, 74); font-family: Avenir, -apple-system-font, 微软雅黑, sans-serif;"},"namespaceURI":"http://www.w3.org/1999/xhtml"}]'
+            >我另外调用了自己平时发起Pull Request的指令，自动创建PR#10, #11,
+            #12。</span
+          >
+        </p>
+        <p>
+          <span><span leaf="">☞&nbsp;</span></span
+          ><span
+            ><span leaf=""
+              ><a
+                href="https://github.com/beiciliang/intro2musictech/pulls?q=is%3Aclosed+author%3Abeiciliang"
+                target="_blank"
+                rel="noopener"
+                >https://github.com/beiciliang/intro2musictech/pulls?q=is%3Aclosed+author%3Abeiciliang</a
+              ></span
+            ><span leaf=""><br /></span
+          ></span>
+        </p>
+        <hr />
+        <h3><span leaf="">『交互式 Notebook』</span></h3>
+        <p>
+          <span leaf=""
+            >这是本次更新的重点，一个全新的交互式教程<span textstyle=""
+              >&nbsp;</span
+            ><span textstyle="">MIR-CC.py</span
+            >，基于marimo框架构建。与传统Jupyter Notebook不同，marimo
+            notebook的每个单元格都是响应式的：修改一个参数，所有依赖它的图表会自动重新计算和刷新，无需手动重跑。</span
+          >
+        </p>
+        <p>
+          <span leaf=""
+            >整个教程以「和 Claude Code 结对编程」为主线，模拟读者向 AI 提问、AI
+            给出代码并实时运行的学习场景，分为六个部分：</span
+          >
+        </p>
+        <p>
+          <span leaf=""
+            >Part 0 — 开场白： 介绍Claude
+            Code是什么、为什么它能帮助零基础读者学习音乐科技，集中导入所有依赖库。</span
+          >
+        </p>
+        <p>
+          <span leaf=""
+            >Part 1 — 加载与聆听：
+            加载音频文件，展示采样率、时长等元数据，支持直接在页面内播放音频，并绘制波形图。这是MIR的第一步：「先听到、再看到」。</span
+          >
+        </p>
+        <p>
+          <span leaf=""
+            >Part 2 — 交互式STFT频谱图：
+            这是交互性最强的部分。读者可以通过下拉菜单从 5
+            个音频样本中选择，然后拖动两个滑块实时调节：</span
+          >
+        </p>
+        <ul>
+          <li>
+            <p>
+              <span leaf="">n_fft（FFT 窗口大小</span
+              ><span leaf="">，256 ~ 4096） 控制频率分辨率</span>
+            </p>
+          </li>
+          <li>
+            <p>
+              <span leaf=""
+                >hop_length（跳跃步长，64 ~ 2048）控制时间分辨率</span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>
+          <span leaf=""
+            >频谱图会随滑块变化即时刷新，让读者直观感受「时频分辨率的取舍」这一核心概念，而不只是看公式。</span
+          >
+        </p>
+        <p>
+          <span leaf=""
+            >Part 3 — 梅尔频谱图：
+            将线性频谱与梅尔频谱并排对比展示，并提供可调节的n_mels参数。梅尔刻度模拟人耳对频率的非线性感知，是语音识别和音乐分析中最常用的特征表示之一。</span
+          >
+        </p>
+        <p>
+          <span leaf=""
+            >Part 4 — 实用MIR任务： 展示三个经典的音乐信息检索应用：</span
+          >
+        </p>
+        <ul>
+          <li>
+            <p>
+              <span leaf=""
+                >节拍检测（Onset Detection）
+                自动标记音频中的节拍位置，叠加在波形图上</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span leaf=""
+                >色度图对比（Chromagram）同时展示STFT、CQT、CENS三种算法生成的色度图，色度图将音高映射到
+                12 个半音（C, C#, D, ...），是和弦识别和调性分析的基础</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span leaf=""
+                >频谱质心（Spectral
+                Centroid）叠加在频谱图上，直观展示声音「亮度」随时间的变化</span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>
+          <span leaf=""
+            >Part 5 — 音频特征仪表盘：
+            将六种核心特征可视化整合到一个标签页界面中：波形、频谱图、梅尔频谱图、色度图、MFCC（梅尔频率倒谱系数）、频谱质心
+            +
+            过零率。读者可以切换标签页，一站式总览同一段音频的多维度特征。</span
+          >
+        </p>
+        <p>
+          <span leaf=""
+            >Part 6 — 总结与展望：
+            回顾所学内容，提供进一步学习的资源链接。</span
+          >
+        </p>
+        <p><span leaf="">本地运行指令：</span></p>
+        <section>
+          <pre
+            data-lang="bash"
+          ><code><span leaf="">uv&nbsp;<span>sync</span></span></code><code><span leaf="">uv run marimo edit MIR-CC.py</span></code></pre>
+        </section>
+        <p>
+          <span
+            ><span leaf=""
+              >☞ 顺便展示一下做这个更新时CC自动发起的PR#13</span
+            ></span
+          >
+        </p>
+        <section nodeleaf="">
+          <img
+            data-aistatus="1"
+            type="block"
+            data-original-style="null"
+            data-index="2"
+            src="https://mmbiz.qpic.cn/mmbiz_png/FJfic83TmLLvC4D53xeHjwyAQLl8Gsn3SnBsO7x9cvVlIeomfLzdhZOOjpeKXpGzlJLzXKZiacGNg3jITyTKQ9hR4icwwRI58ZImkrR0ZtUJes/640"
+            _width="677px"
+            alt="Image"
+          />
+        </section>
+        <hr />
+        <h3><span leaf="">『在线预览』</span></h3>
+        <p>
+          <span
+            ><span leaf=""
+              >并非所有读者都希望在本地搭建环境才能看到上面的教程内容。PR#14将
+              MIR-CC notebook 通过marimo export
+              html导出为一个完整的静态HTML文件（docs/index.html），并配置GitHub
+              Pages从main分支的/docs目录部署。</span
+            ></span
+          >
+        </p>
+        <p>
+          <span leaf=""
+            >读者只需打开这个链接即可在浏览器中看到教程内容和所有预渲染的图表：</span
+          >
+        </p>
+        <p>
+          <span
+            ><span
+              leaf=""
+              data-pm-slice='1 1 ["para",{"tagName":"p","attributes":{"style":"margin-top: 15px; margin-bottom: 15px; box-sizing: border-box; font-size: 16px; white-space: pre-line; line-height: 1.6em; color: rgb(74, 74, 74); font-family: Avenir, -apple-system-font, 微软雅黑, sans-serif;"},"namespaceURI":"http://www.w3.org/1999/xhtml"},"node",{"tagName":"span","attributes":{"style":"font-size: 14px;"},"namespaceURI":"http://www.w3.org/1999/xhtml"}]'
+              >☞&nbsp;</span
+            ></span
+          ><span leaf=""
+            ><a
+              href="https://beiciliang.github.io/intro2musictech/"
+              target="_blank"
+              rel="noopener"
+              >https://beiciliang.github.io/intro2musictech/</a
+            ></span
+          >
+        </p>
+        <p>
+          <span leaf=""
+            >需要注意的是，静态版本中的交互组件（滑块、下拉框、标签页切换）仅作为视觉展示，无法实际拖动操作。如果想要完整的交互体验，仍然需要在本地通过
+            uv run marimo edit MIR-CC.py 运行。</span
+          >
+        </p>
+        <p><span leaf="">以下为截图：</span></p>
+        <section nodeleaf="">
+          <img
+            data-aistatus="1"
+            type="block"
+            data-original-style="null"
+            data-index="3"
+            src="https://mmbiz.qpic.cn/sz_mmbiz_png/FJfic83TmLLubEViahkia3ov174ibmXJ4FhYpibJG0eHZzFK4TM3be8tgA6T1ibRCKo8sATMBNAOrp67lwQJibeYP0SND8OAPOp6a3QFPdiaSAEeiaXQ/640"
+            _width="677px"
+            alt="Image"
+          />
+        </section>
+        <hr />
+        <p>
+          <span
+            ><span leaf=""><span textstyle="">现在回看</span></span
+            ><span leaf=""
+              ><span textstyle="">3年前的</span
+              ><a
+                target="_blank"
+                href="https://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483994&amp;idx=1&amp;sn=3dfeefafc11c264106f448379052b42d&amp;scene=21#wechat_redirect"
+                textvalue="「INFO」分享我的MIR研发技术栈"
+                data-itemshowtype="0"
+                linktype="text"
+                data-linktype="2"
+                link-id="5210"
+                ><span textstyle="">「INFO」分享我的MIR研发技术栈</span></a
+              ><span textstyle=""
+                >自己都觉得过时，2026年的编程体验一定还会有更加翻天覆地的变化，希望我还能想起更新这个公众号，感谢大家一直以来的关注！</span
+              ></span
+            ></span
+          >
+        </p>
+        <p>
+          <span
+            ><strong><span leaf="">点</span></strong></span
+          ><strong
+            ><span leaf="">击下方</span
+            ><span><span leaf="">阅读原文</span></span
+            ><span leaf="">可直达intro2musictech代码仓库</span></strong
+          >
+        </p>
+        <p data-pm-slice="3 3 []">
+          <span><span leaf="">☞&nbsp;</span></span
+          ><span
+            ><span leaf=""
+              ><a
+                href="https://github.com/beiciliang/intro2musictech"
+                target="_blank"
+                rel="noopener"
+                >https://github.com/beiciliang/intro2musictech</a
+              ></span
+            ></span
+          >
+        </p>
+        <p><mp-style-type data-value="3"></mp-style-type></p>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/conferences-journals.html
+++ b/articles/conferences-journals.html
@@ -1,0 +1,828 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>「INFO」音乐科技相关会议期刊列表 - 无痛入门音乐科技</title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「INFO」音乐科技相关会议期刊列表</h1>
+      <div class="meta">2018年11月30日 14:26 · 无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            在知乎回答问题的时候发现，大多数人对音乐科技这个小众行业的了解真的是太少了，国际上有哪些会议和期刊的文章值得看一看也是不清不楚，所以我从组里的日历复制粘贴，给大家这么一份列表参考一下，希望有帮助！
+          </p>
+        </blockquote>
+        <p>
+          <span
+            >以下国际会议按投稿截止日期的先后排列（2018年12月至2019年年末），期刊则按影响力从高到低排列。</span
+          >
+        </p>
+        <p>
+          <span>♬ </span><span>加下划线</span
+          ><span
+            >的是我们C4DM参与度较高的会议，每次组里能有好多人“中奖”，或者在我们这儿承办过，或有老师担任组委会委员♬</span
+          >
+        </p>
+        <hr />
+        <h3>『国际会议』</h3>
+        <ul>
+          <li>
+            <p>
+              <span
+                >IEEE International Conference on Multimedia and Expo
+                (ICME)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>Extended Semantic Web Conference (ESWC)</span></p>
+          </li>
+          <li>
+            <p><span>Music Encoding Conference (MEC)</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                >International Joint Conference on Neural Networks (IJCNN)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>Interdisciplinary Workshop on Timbre (Timbre)</span></p>
+          </li>
+          <li>
+            <p><span>Extended Semantic Web Conference (ESWC)</span></p>
+          </li>
+          <li>
+            <p>
+              <span>International Workshop on Folk Music Analysis (FMA)</span>
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >Signal Proceedings with Adaptive Sparse Structured
+                Representations (SPARS)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>Designing Interactive Systems (DIS)</span></p>
+          </li>
+          <li>
+            <p><span>Rhythm Production and Perception Workshop (RPPW)</span></p>
+          </li>
+          <li>
+            <p>
+              <span>International Symposium on Musical Acoustics (ISMA)</span>
+            </p>
+          </li>
+          <li>
+            <p>
+              <span>International Conference on Machine Learning (ICML)</span>
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >International Conference on Mathematics and Computation in
+                Music (MCM)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >International Conference on New Interfaces for Musical
+                Expression (NIME)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >ACM International Conference Multimedia Retrieval (ICMR)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >International Conference on Movement and Computing (MOCO)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>ACM SIGGRAPH</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                >International Conference of Students of Systematic Musicology
+                (SYSMUS)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >IEEE VR Workshop on Sonic Interactions for Virtual Environments
+                (SIVE)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span>IEEE Workshop on Statistical Signal Processing (SSP)</span>
+            </p>
+          </li>
+          <li>
+            <p><span>AES Conference on Audio Forensics</span></p>
+          </li>
+          <li>
+            <p><span>AES Conference on Semantic Audio</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                >Society for Music Perception and Cognition Meeting (SMPC)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >ACM SIGKDD Conference on Knowledge Discovery and Data Mining
+                (KDD)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>International Conference on New Musical Concepts</span></p>
+          </li>
+          <li>
+            <p><span>ACM Creativity and Cognition (ACM CC)</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                >International Sound and Music Computing Conference (SMC)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>International Computer Music Conference (ICMC)</span></p>
+          </li>
+          <li>
+            <p><span>European Signal Processing Conference (EUSIPCO)</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                >IEEE Sensor Array and Multichannel Signal Processing Workshop
+                (SAM)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>IEEE Irish Signals and Systems Conference (ISSC)</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                >AES International Conference on Immersive and Interactive
+                Audio</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >International Conference on Latent Variable Analysis and Signal
+                Separation (LVA/ICA)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >International Society for Music Information Retrieval
+                Conference (ISMIR)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >International Workshop on Deep Learning for Music (IJCNN
+                Workshop)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >International Conference on Spoken Language Processing
+                (Interspeech)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >International Conference on Digital Audio Effects (DAFx)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>ACM International Conference on Multimedia (MM)</span></p>
+          </li>
+          <li>
+            <p><span>International Semantic Web Conference (ISWC)</span></p>
+          </li>
+          <li>
+            <p><span>ACM Recommender Systems (RecSys)</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                >IEEE Workshop on Applications of Signal Proceedings to Audio
+                and Acoustics (WASPAA)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >International Symp on Computer Music Multidisciplinary Research
+                (CMMR)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>Web Audio Conference (WAC)</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                >ACM International Conference on Multimodal Interaction
+                (ICMI)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>Music Production Education Conference (MPEC)</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                >IEEE International Workshop on Machine Learning for Signal
+                Processing (MLSP)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span>IEEE Workshop on Multimedia Signal Processing (MMSP)</span>
+            </p>
+          </li>
+          <li>
+            <p>
+              <span>International Workshop on Machine Learning and Music</span>
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >Machine Learning for Music Discovery Workshop (ICML
+                Workshop)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >Conference on Computer Simulation of Musical Creativity</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>International Bioacoustics Congress (IBAC)</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                >Conference on Neural Information Processing Systems
+                (NIPS)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>Audio Mostly</span></p>
+          </li>
+          <li>
+            <p><span>AES US Convention</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                >IEEE Global Conference on Signal and Information Processing
+                (GlobalSIP)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>Workshop on Intelligent Music Production (WIMP)</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                >International Conference on Digital Libraries for Musicology
+                (DLfM)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>International Conference on 3D Immersion (IC3D)</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                >DCASE 2018: Workshop on Detection and Classification of
+                Acoustic Scenes and Events</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >ACM International Conference on Human Factors in Computing
+                Systems (CHI)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >IEEE FRUCT23 International Workshop on Semantic Audio and the
+                Internet of Things (ISAI18)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >International Conference on Learning Representations
+                (ICLR)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >International Conference on Semantic Computing (IEEE
+                ICSC)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >Special Issue: IEEE STSP, Data Science: Machine Learning for
+                Audio Signal Processing</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >International Conference on Artificial Intelligence and
+                Statistics (AISTATS)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>ML4Audio (NIPS Workshop)</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                >IEEE International Conference on Acoustics, Speech, and Signal
+                Processing (ICASSP)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>IEEE Data Compression Conference (DCC)</span></p>
+          </li>
+          <li>
+            <p><span>AES European Convention</span></p>
+          </li>
+          <li>
+            <p>
+              <span>Digital Music Research Network Annual Meeting (DMRN)</span>
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >International Conference on Analytical Approaches to World
+                Music (AAWM)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >International Conference on Music Perception and Cognition
+                (ICMPC)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span>Multilayer Music Representation and Processing (MMRP)</span>
+            </p>
+          </li>
+        </ul>
+        <hr />
+        <h3>『期刊』</h3>
+        <ul>
+          <li>
+            <p><span>Trends in Cognitive Sciences</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                >IEEE Transactions on Pattern Analysis and Machine
+                Intelligence</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>IEEE Signal Processing Magazine</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                >IEEE Transactions on Neural Networks and Learning Systems</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>SIAM Review</span></p>
+          </li>
+          <li>
+            <p><span>IEEE Transactions on Cybernetics</span></p>
+          </li>
+          <li>
+            <p><span>IEEE Transactions on Human-Machine Systems</span></p>
+          </li>
+          <li>
+            <p><span>IEEE Transactions on Robotics</span></p>
+          </li>
+          <li>
+            <p>
+              <span>IEEE Transactions on Knowledge and Data Engineering</span>
+            </p>
+          </li>
+          <li>
+            <p><span>Pattern Recognition</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                >IEEE/ACM Transactions on Audio, Speech and Language
+                Processing</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>IEEE Transactions on Affective Computing</span></p>
+          </li>
+          <li>
+            <p><span>Machine Learning</span></p>
+          </li>
+          <li>
+            <p><span>Journal of Machine Learning Research</span></p>
+          </li>
+          <li>
+            <p><span>Neural Networks</span></p>
+          </li>
+          <li>
+            <p><span>IEEE Transactions on Multimedia</span></p>
+          </li>
+          <li>
+            <p>
+              <span>Transactions on Automation Science and Engineering</span>
+            </p>
+          </li>
+          <li>
+            <p><span>IEEE Transactions on Information Theory</span></p>
+          </li>
+          <li>
+            <p><span>PLoS One</span></p>
+          </li>
+          <li>
+            <p><span>Journal of Artificial Intelligence Research</span></p>
+          </li>
+          <li>
+            <p><span>Pattern Recognition Letters</span></p>
+          </li>
+          <li>
+            <p><span>Neural Computation</span></p>
+          </li>
+          <li>
+            <p><span>Neurocomputing</span></p>
+          </li>
+          <li>
+            <p><span>International Journal of Social Robotics</span></p>
+          </li>
+          <li>
+            <p><span>ACM Transactions on Computer-Human Interaction</span></p>
+          </li>
+          <li>
+            <p><span>Signal Processing</span></p>
+          </li>
+          <li>
+            <p><span>IEEE Signal Processing Letters</span></p>
+          </li>
+          <li>
+            <p><span>Music Perception</span></p>
+          </li>
+          <li>
+            <p><span>Journal of the Acoustical Society of America</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                >Proceedings of the Royal Society of London. Mathematical,
+                Physical and Engineering Sciences</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>Human-Computer Interaction</span></p>
+          </li>
+          <li>
+            <p><span>Applied Acoustics</span></p>
+          </li>
+          <li>
+            <p>
+              <span>International Journal of Human-Computer Interaction</span>
+            </p>
+          </li>
+          <li>
+            <p><span>International Journal of Human-Computer Studies</span></p>
+          </li>
+          <li>
+            <p><span>Acta Acustica united with Acustica</span></p>
+          </li>
+          <li>
+            <p><span>Journal of the Audio Engineering Society</span></p>
+          </li>
+          <li>
+            <p><span>IEEE Pervasive Computing</span></p>
+          </li>
+          <li>
+            <p><span>IET Signal Processing</span></p>
+          </li>
+          <li>
+            <p><span>Journal on Multimodal User Interfaces</span></p>
+          </li>
+          <li>
+            <p><span>Journal of New Music Research</span></p>
+          </li>
+          <li>
+            <p><span>ACM Transactions on Applied Perception</span></p>
+          </li>
+          <li>
+            <p>
+              <span>EURASIP Journal on Audio Speech and Music Processing</span>
+            </p>
+          </li>
+          <li>
+            <p><span>EURASIP Journal on Advances in Signal Processing</span></p>
+          </li>
+          <li>
+            <p><span>Organised Sound</span></p>
+          </li>
+          <li>
+            <p><span>Applied Sciences</span></p>
+          </li>
+          <li>
+            <p><span>Computational Intelligence and Neuroscience</span></p>
+          </li>
+          <li>
+            <p><span>Journal of Mathematics and Music</span></p>
+          </li>
+          <li>
+            <p><span>Computer Music Journal</span></p>
+          </li>
+          <li>
+            <p><span>Leonardo Music Journal</span></p>
+          </li>
+        </ul>
+        <hr />
+        <p>
+          <span
+            >对世界上有哪些音乐科技科研组感兴趣的同学可查看往期文章或下方链接里的列表（持续更新中）：</span
+          >
+        </p>
+        <ul>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="https://github.com/beiciliang/intro2musictech/blob/master/INFO-ResearchGroups.md"
+                  target="_blank"
+                  rel="noopener"
+                  >https://github.com/beiciliang/intro2musictech/blob/master/INFO-ResearchGroups.md</a
+                ></span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <a
+                href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483709&amp;idx=1&amp;sn=eec4ff8a5ea988228c800c3f2c5646b1&amp;chksm=fe0d9f92c97a1684f053d0ccd88486840af6d6847d58df9ad7ac39c4e3b5136bcadffce5a71e&amp;scene=21#wechat_redirect"
+                target="_blank"
+                ><span>「INFO」音乐科技相关科研组列表</span></a
+              ><br />
+            </p>
+          </li>
+        </ul>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/intro-music-tech.html
+++ b/articles/intro-music-tech.html
@@ -1,0 +1,202 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>「INFO」三分钟认识音乐科技 - 无痛入门音乐科技</title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「INFO」三分钟认识音乐科技</h1>
+      <div class="meta">2021年8月6日21:39 · 无痛入门音乐科技</div>
+      <div class="content">
+        <div id="js_common_share_desc_wrap">
+          <div>
+            <span id="js_common_share_desc"
+              >中文字幕by梁贝茨博士✨&nbsp;欢迎关注其公众号“无痛入门音乐科技”了解更多科普知识！<br /><br />原视频信息如下：<br />The
+              Science Behind Music Technology: An animated story.<br /><a
+                href="https://www.youtube.com/watch?v=YgYV-7-ohxQ"
+                target="_blank"
+                rel="noopener"
+                >https://www.youtube.com/watch?v=YgYV-7-ohxQ</a
+              ><br /><br />by MIP-Frontiers consortium (QMUL, UPF, TP, JKU,
+              Roli, Sony SCL, DoReMir)<br /><a
+                href="https://mip-frontiers.eu/"
+                target="_blank"
+                rel="noopener"
+                >https://mip-frontiers.eu/</a
+              ></span
+            >
+          </div>
+        </div>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/mir-tech-stack.html
+++ b/articles/mir-tech-stack.html
@@ -1,0 +1,298 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>「INFO」分享我的MIR研发技术栈 - 无痛入门音乐科技</title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「INFO」分享我的MIR研发技术栈</h1>
+      <div class="meta">2023年3月26日 04:48 · 无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            在被OpenAI彻底攻克所有技术前，记录分享下我做音乐信息检索项目涉及的技术栈，希望对大家有所帮助！
+          </p>
+        </blockquote>
+        <section>
+          <span>本文主要附带以下视频中提到的一些链接和教程：</span><br />
+        </section>
+        <section>
+          <mp-common-videosnap
+            data-parentwidth="677"
+            data-maxwidth="677"
+            data-index="0"
+            data-url="https://findermp.video.qq.com/251/20350/stodownload?encfilekey=oibeqyX228riaCwo9STVsGLM5YtWluFOonlGV4t19g28brkQkK9Do3D04SFzicXOiaIjeZOGMPMXqagt5iadYfapWiaIjJaHPhh0icZ3EJMBnjUcNg7tRZILk0ecBDriaF2oT5qXsicYicNMmxyWQ&amp;token=6xykWLEnztInVhe2jPAaH5mzyRg6micgMwvPIVMVicjmLYd8g5guznTBxyPQdiaZnzurmJJkXl41via6s0YF8yxbB4Q66m7gGa9nhf0rUjN7NfcG5yygjqibgSqNDEC1sPtamltKm5ogE9TSNNKfJEicUH6MKs7lEnbkcazT0UckQXDobtOP9crMic8q4iaKns7BRCIvJmgssjl0eHJARTghzbx5rD9WBnFYUq1gKy3zxMGWicyE&amp;bizid=1023&amp;dotrans=0&amp;hy=HK&amp;idx=1&amp;m=63bb831b6a33fab4854e4b2f7aa3d779&amp;wxampicformat=503&amp;picformat=200"
+            data-headimgurl="https://wx.qlogo.cn/finderhead/Q3auHgzwzM5ibSfabvGhFuCS0Bic9c9DnDV40YkMPguMWmdSLxZFoJ3w/0"
+            data-username="v2_060000231003b20faec8cae08a18cad1ce02ea30b07746d38993b15a438d0c95891c9bf6259e@finder"
+            data-nickname="大贝茨"
+            data-desc="#无痛入门音乐科技 #MIR"
+            data-flag="0"
+            data-nonceid="12860043239641973792"
+            data-type="video"
+            data-authiconurl=""
+            data-feedsharecoverurl=""
+            data-feedfullcoverurl="https://findermp.video.qq.com/251/20350/stodownload?encfilekey=oibeqyX228riaCwo9STVsGLM5YtWluFOonlGV4t19g28brkQkK9Do3D04SFzicXOiaIjeZOGMPMXqagt5iadYfapWiaIjJaHPhh0icZ3EJMBnjUcNg7tRZILk0ecBDriaF2oT5qXsicYicNMmxyWQ&amp;token=6xykWLEnztInVhe2jPAaH5mzyRg6micgMwvPIVMVicjmLYd8g5guznTBxyPQdiaZnzurmJJkXl41via6s0YF8yxbB4Q66m7gGa9nhf0rUjN7NfcG5yygjqibgSqNDEC1sPtamltKm5ogE9TSNNKfJEicUH6MKs7lEnbkcazT0UckQXDobtOP9crMic8q4iaKns7BRCIvJmgssjl0eHJARTghzbx5rD9WBnFYUq1gKy3zxMGWicyE&amp;bizid=1023&amp;dotrans=0&amp;hy=HK&amp;idx=1&amp;m=63bb831b6a33fab4854e4b2f7aa3d779&amp;wxampicformat=503&amp;picformat=200"
+            data-feedthumburl="https://findermp.video.qq.com/251/20350/stodownload?encfilekey=oibeqyX228riaCwo9STVsGLM5YtWluFOonfwfjgOcZXny2xqEoj1CVgJpEB3LQxicNb6sXZlD5GfIMKyrVkYiaMt9EO5c6AxqZI65mW4GuaibS3w46hFJApZLArcianVHic9ibu0oy5iayjxjjUs&amp;token=cztXnd9GyrFbm3Mhw2JEHLz8VPRM6Z4LvFfhltt2QwsvSdHd3kZSBjRReriaYrobibVJpl5Xjlnt4lbvHWjzP8wKhAZUWaEmlMr10ia1uibNnvLr21bdibyZZibJSXRCFNuhCeiaog1XZrDicTQdWS1HqHX5GjdrUeFibhVRK9MNUuLq9R1iaPqJpMqsbvP3t7B2bXztkVZxMkusA7mqqFICGJnffxxu4VeXLARrxAlia22ibI5VV58&amp;bizid=1023&amp;dotrans=0&amp;hy=HK&amp;idx=1&amp;m=0e64715a7417e08ee8fdb401e1b7e666&amp;wxampicformat=503&amp;picformat=200"
+            data-feedcoverurl="https://findermp.video.qq.com/251/20304/stodownload?encfilekey=oibeqyX228riaCwo9STVsGLM5YtWluFOontl6HibXiagLxfZOEwriaQDTElic0ucYHB4bTeIEyLics1zXvrRDzyzmpKGPxaiboV6LqRePkibmH2nCvYHBMKvVglMfFkWDHp75qYSlFVroXUQxibZ0&amp;token=Cvvj5Ix3eeylYM13THwvFR6aMWlxGrjx5tHiaBJiapnt5lyqGLgribQia6XXDSXoH5uJs8qYatSxAXuQI7l32FcQQMgYLRnGMicvyafbAG7Xyia03iac0F5rllIBhGvjvSMo6AbTRwUqDL6yvbhXM2lLnoll1Ju9GDhlhtrVh8rJRqlKjH5xIOPTFthN7JnZpSiaBs306goRX2PbqNcjiabZKp7WS2afHGlmP13I5Sflwqef8KAI&amp;bizid=1023&amp;dotrans=0&amp;hy=HK&amp;idx=1&amp;m=fdf9f9efad19c780cca4de446689eeba&amp;wxampicformat=503&amp;picformat=200"
+            data-width="1728"
+            data-height="1080"
+            data-isnews="0"
+            data-likenum="35"
+            data-id="export/UzFfAgtgekIEAQAAAAAAqkURoV2jSAAAAAstQy6ubaLX4KHWvLEZgBPEi6NYbQR4LKOAzNPgMIskfC2JQzDfhYuE3xdNWSkE"
+          ></mp-common-videosnap>
+        </section>
+        <section><span></span></section>
+        <p>
+          <span
+            >关于用Python做API，下面链接里19个小时的YouTube视频教程对我帮助很大，里面涵盖设计API用的</span
+          ><span>routes, serialization/deserializat</span
+          ><span
+            >ion, schema validation等知识，也涉及SQL，用pytest做测试，和用GitHub
+            Actions做CI/CD的知识。</span
+          >
+        </p>
+        <p>
+          <span
+            ><span>☞ 视频:&nbsp;</span
+            ><span
+              ><a
+                href="https://youtu.be/0sOvCWFmrtA"
+                target="_blank"
+                rel="noopener"
+                >https://youtu.be/0sOvCWFmrtA</a
+              ></span
+            ></span
+          >
+        </p>
+        <p>
+          <span
+            >学习Flask,
+            Django等基于Python的后端框架，及React前端框架，除了官方教程，我主要参考学习Miguel
+            Grinberg的博客。</span
+          >
+        </p>
+        <p>
+          <span
+            ><span>☞ 博客:&nbsp;</span
+            ><span
+              ><a
+                href="https://blog.miguelgrinberg.com"
+                target="_blank"
+                rel="noopener"
+                >https://blog.miguelgrinberg.com</a
+              ></span
+            ></span
+          ><span></span><span></span>
+        </p>
+        <p>
+          <span
+            >我还在跟进的AWS Cloud Project
+            Bootcamp，进度记录在下面我的GitHub链接中。这个需要有前后端基础，主要提升作为云开发工程师或云架构师的技能。可用GitPod进行演示，基本等同于GitHub
+            Codespace的作用（网页版Visual Studio Code）。</span
+          >
+        </p>
+        <p>
+          <span
+            >☞&nbsp;<span
+              ><a
+                href="https://github.com/beiciliang/aws-bootcamp-cruddur-2023"
+                target="_blank"
+                rel="noopener"
+                >https://github.com/beiciliang/aws-bootcamp-cruddur-2023</a
+              ></span
+            ></span
+          >
+        </p>
+        <p>
+          <span
+            >你要是也想记录或分享自己的技术栈，不妨试试Jupyter
+            Book，比如下面链接里关于音乐分类的教程就是用它做的！</span
+          >
+        </p>
+        <p>
+          <span
+            >☞
+            <span
+              ><a
+                href="https://music-classification.github.io/tutorial"
+                target="_blank"
+                rel="noopener"
+                >https://music-classification.github.io/tutorial</a
+              ></span
+            ></span
+          >
+        </p>
+        <p><mp-style-type data-value="3"></mp-style-type></p>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/music-copyright.html
+++ b/articles/music-copyright.html
@@ -1,0 +1,414 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>「INFO」从数据角度聊聊音乐版权版税 - 无痛入门音乐科技</title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「INFO」从数据角度聊聊音乐版权版税</h1>
+      <div class="meta">2022年10月17日 16:24 · 无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            一个音乐人清楚自己的音乐作品和录音制品有哪些版权
+            (copyright)，才能清楚之后会收入哪些版税
+            (royalty)。即使知道这些“基础知识”，存在于音乐产业各个链条中的数据问题，还是不可避免地导致版权和版税的折损。那么问题到底出在哪里？
+          </p>
+        </blockquote>
+        <p>
+          <span
+            >博主去年从“面向听众”的腾讯音乐离职后，搬到了挪威并加入了一家“面向创作者”的音乐初创。因为同事们都是音乐制作出版发行的背景，就跟着学了不少行业知识，同时也从技术角度观察到音乐数据中尤其是元数据
+            (metadata)
+            的问题。当涉及到不同国家地区之间不同音乐版权版税规则下的数据置换，数据问题就更加复杂和严重，导致版税无法给到相应的音乐人，比如2021年仅在北美地区就有4亿多美元的音乐版税被搁置。为了把数据问题说明白，这篇文章主要会科普以下内容：<br
+          /></span>
+        </p>
+        <ul>
+          <li>
+            <p><span>音乐作品和录音制品的区别</span></p>
+          </li>
+          <li>
+            <p><span>版权版税和相应机构的简介</span></p>
+          </li>
+          <li>
+            <p><span>音乐数据中的问题</span></p>
+          </li>
+        </ul>
+        <hr />
+        <h3>『音乐作品vs录音制品』</h3>
+        <p>
+          <span
+            >当我们提到一首歌，会涉及到两个概念：音乐作品 (musical work or song)
+            和录音制品 (sound recording or
+            master)，这两者会有相应的版权，再由不同机构分别收集版税，即版权使用费。音乐作品包括作曲家创作的旋律、作词家写的歌词等等，录音制品则是由歌手等人表演并录制作品、混音和母带制作后得到的最终录音，可能有不同版本的录音被发行&nbsp;(比如伴奏版、remaster版等等)。因此一个音乐作品可对应到多个录音制品。</span
+          >
+        </p>
+        <p>
+          <span
+            >音乐作品可以经由出版商 (publisher) 在其所在地区的著作权收集协会
+            (collection society) 注册，得到代表该作品的ISWC编号 (International
+            Standard Musical Work Code)。录音制品则是通过唱片公司 (record label)
+            或发行商 (distributor) 注册，得到代表该录音的ISRC编号 (International
+            Standard Recording Code)。一个ISWC可关联到多个ISRC。</span
+          >
+        </p>
+        <p>
+          <span
+            >至此我们可以理解内容平台开发类似YouTube的Content
+            ID系统的必要性：比如在用户上传的内容中，找到其所用音乐对应的录音ISRC和作品ISWC。用音频指纹可以识别到特定的录音，版税收入就能给到这个录音对应的歌手等人，以及这个录音关联到的音乐作品的创作人。如果用户没使用音乐录音而是上传了一首自己的翻唱，则需要用到更复杂的翻唱识别算法找到相似的录音和关联的作品，版税收入就只分配到创作人一方。当然如果音乐作品和录音制品的版权压根就没有授予其他人，<span
+              >Content ID一旦检测到，就应该下架这个用户上传的内容。</span
+            ></span
+          >
+        </p>
+        <p>
+          <span
+            >上面的例子简单涉及到版权和版税内容，实际情况要复杂的多，下面就以在互联网上听歌为例说一说。</span
+          >
+        </p>
+        <hr />
+        <h3>『版权版税和相应机构』</h3>
+        <p>
+          <span
+            >复杂首先体现在不同国家地区的音乐版权不同，其次是不同版权对应的版税由不同机构负责收集，最后是收集到的版税要分配给不同的人。这里借用MLC上的图，简单讲一下北美地区互联网上使用音乐时涉及的版权版税和相应机构
+            (博主注：下文里涉及的一些术语，因为不知道准确的中文翻译，就直接写英文了)。</span
+          >
+        </p>
+        <p>
+          <img
+            data-croporisrc="https://mmbiz.qpic.cn/mmbiz_jpg/7CrMia15fFJUY1y0Z3xKdTqdYt5mffJbaD94S0h7LG95ClbzZmRzl5wRibVbNCT89egSkAGTVkWRsmdPr0PxHFhg/0?wx_fmt=jpeg"
+            data-cropx1="44.325259515570934"
+            data-cropx2="1177.7854671280277"
+            data-cropy1="71.76470588235294"
+            data-cropy2="664.878892733564"
+            data-galleryid=""
+            data-original-style="width: 100%;height: auto;"
+            data-index="2"
+            src="https://mmbiz.qpic.cn/mmbiz_jpg/7CrMia15fFJUY1y0Z3xKdTqdYt5mffJbayjG6A8jvCy56ZxfrYucjicicCo8SCtoexMiccdXSKibia8I4Y5nPafgDvZQ/640"
+            _width="100%"
+            alt="Image"
+          />
+        </p>
+        <p>
+          <span
+            >☞ 图源：<a
+              href="https://www.themlc.com/digital-music-royalties-landscape"
+              target="_blank"
+              rel="noopener"
+              >https://www.themlc.com/digital-music-royalties-landscape</a
+            ></span
+          >
+        </p>
+        <section>
+          <span
+            >目前最主流的听歌方式就是在流媒体平台上搜歌听
+            (比如Spotify)，这种用户主动选择歌曲的收听方式即interactive
+            stream会涉及到：</span
+          >
+        </section>
+        <ol>
+          <li>
+            <section>
+              <span
+                >音乐作品的版权之public performance rights，相应的performance
+                royalty版税会通过北美的著作权收集协会
+                (比如ascap、BMI、SESAC等，取决于作品当时注册在哪一个)
+                来收集，再按作品注册时声明的出版商和创作人之间的比例来分配版税；</span
+              >
+            </section>
+          </li>
+          <li>
+            <section>
+              <span
+                >音乐作品的版权之reproduction and distribution
+                rights，相应的mechanical
+                royalty版税要不由MLC机构来收集，要不由音乐作品关联的录音制品所在发行商来收集
+                (如果事先有签订好合同)，然后分配给出版商和创作人；</span
+              >
+            </section>
+          </li>
+          <li>
+            <section>
+              <span
+                >录音制品的版权之reproduction and distribution
+                rights，相应的版税即歌曲销量收入由发行商收集后，分配给唱片公司和歌手等人。</span
+              >
+            </section>
+          </li>
+        </ol>
+        <p>
+          <span
+            >如果用户在数字平台上特意买了一首歌下载后不受限地听，即permanent
+            download，那只涉及上文ii和iii这两种版权版税。如果歌曲在电台类的数字平台上播放
+            (比如Pandora)，用户不能自主选择，歌曲中的音乐作品涉及i中的版权版税，而录音制品则涉及digital
+            performance
+            rights，相应的版税由soundexchange机构收集后，按事先规定好的比例分配给唱片公司和歌手等人。<br
+          /></span>
+        </p>
+        <p>
+          <span
+            >无论是哪种方式，录音制品相关的版税收入，因为数字平台和发行商之间能直接沟通，收入大多能准确地分配到唱片公司和歌手手里。但音乐作品相关的版税收入，由于要经由不同国家地区的著作权收集协会分别收集，此外还要通过出版商，作词作曲人的收入既不及时也不准确。再加上下一部分提到的数据问题，只能说创作人赚点钱好难！</span
+          >
+        </p>
+        <hr />
+        <h3>『音乐数据中的问题』</h3>
+        <p>
+          <span
+            >以上文i中涉及的情况为例 (音乐作品的<span
+              >public performance rights</span
+            >)，某个流媒体平台会将北美地区各个录音制品的收听记录发给北美地区的某个著作权收集协会，由该协会负责识别记录中的录音制品应该对应到注册在该协会下的哪个音乐作品，以此确定版税。最理想的情况是，记录中录音制品的ISRC都有关联的ISWC，就能直接定位到音乐作品，同时在该作品的注册记录下，每个创作人都有IPI或ISNI编号，那么版权收入就能准确地分发给创作人。可惜实际情况却是：</span
+          >
+        </p>
+        <ul>
+          <li>
+            <p>
+              <span
+                >录音制品没有关联到音乐作品，需要通过录音制品的歌曲标题、歌手等元数据匹配到音乐作品，完成ISRC和ISWC之间的关联；</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >即使定位到了音乐作品，但因为该作品的注册记录下有缺失数据，无法准确识别相应的创作人。比如缺少IPI或ISNI编号时，提到英国摇滚乐队的鼓手Roger
+                Taylor，也许是Queen的Roger (Meddows) Taylor，也有可能是Duran
+                Duran的Roger (Andrew) Taylor。</span
+              ><br />
+            </p>
+          </li>
+        </ul>
+        <p>
+          <span
+            ><span>著作权收集协会在</span
+            >关联ISRC和ISWC时，使用的技术目前还停留在基于文本的匹配，另外元数据本身还有大大小小的问题，所以第一步就卡住了。更不用提收集不同国家地区产生的版税时，仅由不同语言之间的文本翻译带来的识别问题
+            (比如弄混姓和名的前后顺序)。A$AP
+            Rocky他也许永远不知道，本意想赚更多$而起的名字，在各种系统的不同字符编码之间做匹配后，会少赚多少…<br
+          /></span>
+        </p>
+        <p>
+          <span
+            ><span>✎&nbsp;</span
+            >下面链接里的博客里有更多奇奇怪怪的音乐数据例子：</span
+          ><span
+            ><a
+              href="https://dustri.org/b/horrible-edge-cases-to-consider-when-dealing-with-music.html"
+              target="_blank"
+              rel="noopener"
+              >https://dustri.org/b/horrible-edge-cases-to-consider-when-dealing-with-music.html</a
+            ></span
+          >
+        </p>
+        <hr />
+        <p>
+          <span
+            >最后，如果你是一个全能音乐人，既作曲又唱歌，从音乐作品到录音制品都能办，那么记住以下几件事，保证你的音乐收益：</span
+          >
+        </p>
+        <ul>
+          <li>
+            <p>
+              <span
+                >确保音乐作品和录音制品两个层面里元数据的准确，除了歌曲名字等数据，你也要有ISNI等表示“你是你”的身份编号
+                (ISNI是近年较通用可以表示各种身份的编号，IPI主要表示作曲/作词/出版商等音乐作品相关的人，IPN主要表示歌手/乐手/制作人等录音制品相关的人)。</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >作为作曲/作词等音乐作品相关人，成为你所在地区<span
+                  >著作权收集协会的会员，当你创作了一首新的音乐作品，将其注册在该协会并得到作品的ISWC编号。一般是通过出版商完成注册，出版方也负责作品在其他地区协会的注册。</span
+                ></span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><span
+                  >作为歌手/制作人等录音制品相关人，通过唱片公司或发行商使录音能在各个平台收听。该录音的数据中，既要有代表其本身的ISRC编号，也要和对应的音乐作品ISWC相关联。</span
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>
+          <span
+            ><span
+              >在不同的国家地区，也许还要注册一些其他的协会才能全方位地回收各种版税。无论如何，音乐人要尤其注意源头数据的准确，否则错误的数据进入到接下来的音乐产业链条中，再改就既麻烦又缓慢，直接折损音乐人应得的版税收入。已有的匹配识别错误想要得到纠正，除了用更先进的自然语言处理算法甚至图模型，音频数据的加入也是一条解决路线。多模态的音乐信息检索技术，已经落地到不少流媒体平台做搜广推业务，希望之后也能成为真正帮助到音乐创作者的技术
+              :)</span
+            ></span
+          >
+        </p>
+        <p><mp-style-type data-value="3"></mp-style-type></p>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/music-genre.html
+++ b/articles/music-genre.html
@@ -1,0 +1,493 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>「MIR-05_1」音乐流派自动识别的前世今生 - 无痛入门音乐科技</title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「MIR-05_1」音乐流派自动识别的前世今生</h1>
+      <div class="meta">2020年10月8日 13:31 · 无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            世界上有那么多新歌老歌，但各种歌曲之间总能被一些共性联系起来，“流派”就是共性之一。那我们能否通过MIR技术，直接依据音频自动识别出一首歌曲是民谣、乡村、爵士、摇滚、电音…还是哪种流派呢？<br />
+          </p>
+        </blockquote>
+        <section>
+          <span
+            ><strong>♬ 本文为MIR音乐信息检索系列的第10篇文章 ♬</strong></span
+          >
+        </section>
+        <section>
+          <span
+            ><strong><strong></strong></strong
+          ></span>
+        </section>
+        <section>
+          <span
+            >该文针对于“音乐流派” (music
+            genres)，会与后续5.X系列文章共同讲解“基于音频完成自动打标签” (audio
+            auto-tagging)。本文将大致讲解：</span
+          >
+        </section>
+        <ul>
+          <li>
+            <section><span>什么是音乐流派？</span></section>
+          </li>
+          <li>
+            <section><span>近20年来流派识别发展到什么水平？</span></section>
+          </li>
+          <li>
+            <section><span>主要的挑战和未来的方向？</span></section>
+          </li>
+        </ul>
+        <hr />
+        <h3>『音乐流派』</h3>
+        <p>
+          <span
+            >根据《音频音乐与计算机的交融——音频音乐技术》第13章“音乐分类”中提到的定义：音乐的流派或风格常用来描述音乐家及其音乐作品的相似性，传达音乐偏好和品味，并用来组织音乐曲目，是文化、艺术家和音乐市场之间相互影响的产物。</span
+          >
+        </p>
+        <p>
+          <span
+            >大多数人谈论音乐流派时，一般指的是现当代流行文化下的流派，与此同时，不同人对不同流派间的界限感知也是模糊的，对于人脑来说“流派检测”都是一项偏主观的任务，更不用说依赖MIR技术直接从音频中自动识别了。</span
+          >
+        </p>
+        <p>
+          <span
+            >鉴于音乐流派的确切定义还涉及许多音乐专业知识，与其我在这儿长篇大论，不如一图胜千言：</span
+          >
+        </p>
+        <p>
+          <img
+            data-original-style="width: 100%;height: auto;"
+            data-index="2"
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJX3icfhE6q9NznYg7N0p6PCU9jwedXKfRbGIZkSxTiagslGHb3YuzbuyRqbibzfZiceXD8Ozk7PWbvohw/640"
+            _width="100%"
+            alt="Image"
+            data-report-img-idx="0"
+          /><span>以上截图来源于我最爱的可以交互式认识音乐流派的网站</span
+          ><em>musicmap.info</em
+          ><span
+            >，图片中圆圈/长方条出现的位置表示该流派出现的时间早晚，比如最上方的四大圆圈都是世界上较早出现的音乐流派/类型（utility主要指带某种功能的音乐比如宗教音乐，folk主要指传统民谣，classical就是古典音乐了，world泛指世界各地的民族音乐），下面</span
+          ><span>五颜六色</span
+          ><span
+            >的长方条就是大家更熟悉的流行音乐流派，颜色越相近，流派越相似。</span
+          >
+        </p>
+        <p>
+          <span
+            >如果流派之间真的就像上图那样分立，那事情就简单得多了，然而我们放大图片后看到的事实是这样的：</span
+          >
+        </p>
+        <p>
+          <img
+            data-original-style="width: 100%;height: auto;"
+            data-index="3"
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJX3icfhE6q9NznYg7N0p6PCU6HeHI2AOQ0icIcKl3p7m8fmOLvfSSalQHVXhYd1HpEo3RwwoGKsQeag/640"
+            _width="100%"
+            alt="Image"
+          />
+        </p>
+        <p>
+          <span
+            >能理清不同流派之间的关系，本身就是门复杂的taxonomy/ontology大学问了，在</span
+          ><em>everynoise.com</em
+          ><span
+            >网站上，Spotify的工程师Glenn
+            Mcdonald更是把平台上能“搜刮”到的流派通通通通列了出来。</span
+          >
+        </p>
+        <p><span></span></p>
+        <section>
+          <span>☞ </span
+          ><span
+            ><a href="https://musicmap.info/" target="_blank" rel="noopener"
+              >https://musicmap.info/</a
+            ><br
+          /></span>
+        </section>
+        <section>
+          <span
+            ><span>☞ </span
+            ><span
+              ><a href="http://everynoise.com/" target="_blank" rel="noopener"
+                >http://everynoise.com/</a
+              ></span
+            ></span
+          >
+        </section>
+        <hr />
+        <h3>『流派识别』</h3>
+        <p>
+          <span
+            >所以，当我们谈论“音乐流派的自动识别” (Music Genre Recognition,
+            即MGR) 的时候，到底在谈论什么？</span
+          ><span>这要取决于</span><span>面对的音乐样本大体在哪个范围</span
+          ><span>，以及到底要识别成哪些流派的类</span><span>。</span>
+        </p>
+        <p>
+          <span
+            >学术界里大多受制于音乐数据集，自动识别就变成了一个分类任务。比如，当我们采用被广泛使用的GTZAN数据集时，MGR任务就是将集内的歌曲
+            (其实是30秒的片段)&nbsp;识别为规定好的十大流派之一。<br
+          /></span>
+        </p>
+        <p>
+          <span
+            >截止到2012年年末，已经有500余篇论文研究MGR算法，基于音乐音频做识别占大多数，且大部分采用特征工程的策略，即先对音频进行预处理提取特征，再训练分类模型进行流派识别。鉴于属于同一流派的音乐之间，总会在音色、和声、节奏等方面相似，因此提取的音频特征大多对应以上三种。</span
+          >
+        </p>
+        <p>
+          <span
+            >✎ 以上特征工程相关论文的大调查，可参考文献:&nbsp;Sturm, Bob L. "A
+            survey of evaluation in music genre recognition." International
+            Workshop on Adaptive Multimedia</span
+          ><span><span> Retrieval. Springer, Cham, 2012..</span>&nbsp;</span>
+        </p>
+        <p>
+          <span
+            >然而，音频特征对应到音色等方面时，就已经自带了一层“语义隔阂”&nbsp;(比如说从MFCC的系数变化中，你真的能理解到这是个什么音色么?)，再从中去提取更高的语义信息“流派”，真的会有效么？当然，可以不断地去叠加各种特征，增加模型的训练参数，甚至实现“端到端”从无到有硬生生的学出来。</span
+          >
+        </p>
+        <p>
+          <span
+            ><span>此时此刻</span
+            >这种策略，大家应该都能get到吧？没错，深度学习的时代来临了。</span
+          ><span>这里的</span><span>标杆</span
+          ><span>进展，可以直接搬出三位老</span><span>朋友</span
+          ><span>的名字，大家搜他们的google scholar或个人主页就好</span
+          ><span
+            >（此处并没有“其他人的工作就没啥亮点了”的意思，以下三位确实是连文章带代码都清清楚楚的）：</span
+          >
+        </p>
+        <p>
+          <span
+            ><span>☞&nbsp;</span>Keunwoo
+            Choi：首先将图像领域火起来的CNN、CRNN等模型运用到音乐音频分类任务中
+            (下图a)<br
+          /></span>
+        </p>
+        <p>
+          <span
+            ><span>☞&nbsp;</span>Jordi
+            Pons：改良CNN的前/中/后端，结合音乐先验知识进行各种实验，并已将训练好的musicnn模型集成到Essentia中，开源的榜样！<span
+              >(下图b</span
+            ><span>)</span></span
+          >
+        </p>
+        <p>
+          <span
+            ><span
+              >☞ Jongpil
+              Lee：和以上两位工作里“基于音频的时频谱做输入”不同，直接采用音频的波形，从sample-level搞事情&nbsp;<span
+                >(下图c</span
+              ><span>)</span></span
+            ></span
+          >
+        </p>
+        <p>
+          <img
+            data-croporisrc="https://mmbiz.qlogo.cn/mmbiz_png/7CrMia15fFJX3icfhE6q9NznYg7N0p6PCUPe60BoVGf0ln2INBCvMs6ssIOHPR1QJfYrpeQT6B92vLicuicj5fLibIg/0?wx_fmt=png"
+            data-cropx1="0"
+            data-cropx2="1280"
+            data-cropy1="46.50519031141869"
+            data-cropy2="427.4048442906575"
+            data-original-style='text-align: center;color: rgb(51, 51, 51);font-family: mp-quote, -apple-system-font, BlinkMacSystemFont, "Helvetica Neue", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei UI", "Microsoft YaHei", Arial, sans-serif;font-size: 17px;width: 578px;height: 172px;'
+            data-index="4"
+            src="https://mmbiz.qpic.cn/mmbiz_jpg/7CrMia15fFJX3icfhE6q9NznYg7N0p6PCUuzM1WzL8Q8ln0h4ks9AiaQ2DAZosHDicj7SeSJYez3AGMEj93VWE7gmg/640"
+            _width="578px"
+            alt="Image"
+          /><span></span>
+        </p>
+        <p>
+          <span
+            ><span
+              >鉴于以上深度学习的模型，依赖的环境和评估用的数据集有不同，所以UPF的Minz
+              Won小哥将他们都复现到pytorch中，并和自己的算法 (上图d)
+              做了详细比较，发表在今年的SMC上：</span
+            ></span
+          >
+        </p>
+        <p>
+          <img
+            data-original-style="width: 100%;height: auto;"
+            data-index="5"
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJX3icfhE6q9NznYg7N0p6PCUswISXskqeudCWjWZfTw7UIaXyl3gke5G3NsIE8HE588DI7a8qtIicug/640"
+            _width="100%"
+            alt="Image"
+          />
+        </p>
+        <p>
+          <span
+            >✎ 以上截图来源自文献:&nbsp;Won, Minz, et al. "Evaluation of
+            CNN-based Automatic Music Tagging Models." arXiv preprint
+            arXiv:2006.00751 (2020).</span
+          >
+        </p>
+        <p>
+          <span
+            >☞ 代码可见:
+            <a
+              href="https://github.com/minzwon/sota-music-tagging-models/"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/minzwon/sota-music-tagging-models/</a
+            ></span
+          ><br />
+        </p>
+        <hr />
+        <h3>『挑战与未来』</h3>
+        <p>
+          <span
+            >虽然大量音频数据+深度学习帮助流派识别任务又迈了一大步，但其在工业界的大规模落地还是任重道远。</span
+          >
+        </p>
+        <p>
+          <span
+            >鉴于受过音乐训练的人，听了3秒左右的音乐就能判别出音乐的大类流派
+            (且准确率&gt;70%)，目前训练模型时也都采用3秒到30秒不等的秒级输入。但是当我们真的想准确描述一首歌的流派时，需要考虑整首。片段级的结果如何映射为整曲级？是否要考虑不同结构化片段的权重&nbsp;(比如是否要更看重副歌段落下的检测结果)？</span
+          >
+        </p>
+        <p>
+          <span
+            >模型的输出结果，和“标准答案”不一致时，就真的错了么？即使号召了20位音乐专业人士对一些曲子进行标注，流派结果依然众说纷纭（参考2017年Palmason等人的论文Music
+            Genre Classification Revisited: An In-Depth Examination Guided by
+            Music Experts）。如果判别流派自动标注的性能需要beyond
+            accuracy，那什么是合适的新指标？</span
+          >
+        </p>
+        <p>
+          <span
+            ><span
+              >如果基于音频的自动流派识别只能停留在对大类流派标签的输出，怎样活用其他信息比如歌曲歌词、专辑封面等等，提升某些流派的识别能力？另外，</span
+            ><span>能否</span><span>用</span><span>其中间结果</span
+            ><span>搭建embedding</span><span>，</span><span>辅助其他音乐</span
+            ><span>相关的任务 (比如解决新歌推荐冷启动)</span><span>？</span
+            ><span></span
+          ></span>
+        </p>
+        <p>
+          <span
+            >在真正面对千万级曲库时，如何结合音乐知识，让已有算法迅速对流派标签查缺补漏，而不是只能停留在模型底层的开发？(正所谓用假模假式的fancy模型，掩盖模型开发者本身对音乐知识的欠缺…这个锅，不懂音乐的产品经理也有份)</span
+          >
+        </p>
+        <p>
+          <span
+            >所以说，做MIR还是离不开音乐本乐。否则，即使某天发现了一个<span>识别算法</span>好似万金油，实际却是the
+            famous horse "Clever Hans"。</span
+          >
+        </p>
+        <p>
+          <span
+            ><span>✎&nbsp;</span>上面一句话的典故来自文献: Sturm, Bob L. "A
+            simple method to determine if a music information retrieval system
+            is a “horse”." IEEE Transactions on Multimedia 16.6 (2014):
+            1636-1644.</span
+          >
+        </p>
+        <hr />
+        <p>
+          <span
+            >最后，秉着无痛入门的原则，读者想自己搭建一个流派分类模型，但电脑又不带高端的GPU资源的话，不妨先尝试下“迁移学习”
+            (transfer learning)！</span
+          >
+        </p>
+        <section><span>有条件的话，也可以参考现成的资源：</span></section>
+        <section>
+          <span
+            ><span>☞&nbsp;</span
+            ><a
+              href="http://teaching.jordipons.me"
+              target="_blank"
+              rel="noopener"
+              >http://teaching.jordipons.me</a
+            ></span
+          >
+        </section>
+        <section>
+          <span><br /></span>
+        </section>
+        <p>
+          <strong><span>上文回顾:</span></strong
+          ><a
+            target="_blank"
+            href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483898&amp;idx=1&amp;sn=3a405119a32714442c8dcd9be830cdb9&amp;chksm=fe0d9f55c97a1643a091acb7d6c25c14a8d19d107f9d430ffd9055a468f4d18c43666b2c260f&amp;scene=21#wechat_redirect"
+            data-itemshowtype="0"
+            tab="innerlink"
+            data-linktype="2"
+            >「MIR-05_0」震惊! AI发现这些歌竟然...</a
+          >
+        </p>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/music-language-tutorial.html
+++ b/articles/music-language-tutorial.html
@@ -1,0 +1,438 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>「INFO」连接音乐音频与自然语言 - 无痛入门音乐科技</title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「INFO」连接音乐音频与自然语言</h1>
+      <div class="meta">2026年2月15日 01:25 · 无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            <span leaf=""
+              >博主用Claude Code将ISMIR
+              2024上的一篇高质量教程翻译为中文版，并呈现在Github
+              Pages上，方便读者阅读。</span
+            >
+          </p>
+          <p>
+            <span leaf="">📖&nbsp;</span
+            ><span leaf=""
+              ><a
+                href="https://beiciliang.github.io/intro2musictech/music-language-tutorial"
+                target="_blank"
+                rel="noopener"
+                >https://beiciliang.github.io/intro2musictech/music-language-tutorial</a
+              ></span
+            >
+          </p>
+        </blockquote>
+        <section>
+          <span
+            ><strong
+              ><span leaf=""
+                >♬ 博主发文时还未完整校对，如有勘误请参照英文原版♬</span
+              ></strong
+            ></span
+          >
+        </section>
+        <section>
+          <pre
+            data-lang="typescript"
+          ><code><span leaf=""><span>@book</span>{connecting-music-audio-and-natural-<span>language</span>:book,</span></code><code><span leaf="">&nbsp; &nbsp;&nbsp;<span>Author</span>&nbsp;= {<span>Doh</span>,&nbsp;<span>SeungHeon</span>&nbsp;and&nbsp;<span>Manco</span>,&nbsp;<span>Ilaria</span>&nbsp;and&nbsp;<span>Novack</span>,&nbsp;<span>Zachary</span>&nbsp;and&nbsp;<span>Kim</span>,&nbsp;<span>Jong</span>&nbsp;<span>Wook</span>&nbsp;and&nbsp;<span>Chen</span>,&nbsp;<span>Ke</span>},</span></code><code><span leaf="">&nbsp; &nbsp;&nbsp;<span>Publisher</span>&nbsp;= {<span>https</span>:<span>//mulab-mir.github.io/music-language-tutorial},</span></span></code><code><span leaf="">&nbsp; &nbsp;&nbsp;<span>Title</span>&nbsp;= {<span>Connecting</span>&nbsp;<span>Music</span>&nbsp;<span>Audio</span>&nbsp;and&nbsp;<span>Natural</span>&nbsp;<span>Language</span>},</span></code><code><span leaf="">&nbsp; &nbsp;&nbsp;<span>Year</span>&nbsp;=&nbsp;<span>2024</span>,</span></code><code><span leaf="">&nbsp; &nbsp;&nbsp;<span>Url</span>&nbsp;= {<span>https</span>:<span>//mulab-mir.github.io/music-language-tutorial},</span></span></code><code><span leaf="">}</span></code></pre>
+        </section>
+        <section nodeleaf="">
+          <img
+            data-aistatus="1"
+            type="block"
+            data-original-style="width:578px;height:334px;"
+            data-index="2"
+            src="https://mmbiz.qpic.cn/mmbiz_png/FJfic83TmLLt5icfkhV5CtfPgkIxAiaTQDCudNfXXv5Ptb7NiaicJqal7FNHTSL4e5U1QEHhGIUNvqLVvmvP4L0GnO3CQE4JFJVT48kWAjdY8g68/640"
+            _width="578px"
+            alt="Image"
+            data-report-img-idx="0"
+          />
+        </section>
+        <hr />
+        <h3><span leaf="">『教程内容』</span></h3>
+        <p>
+          <span
+            ><span
+              leaf=""
+              data-pm-slice='1 1 ["para",{"tagName":"p","attributes":{"style":"margin-top: 15px;margin-bottom: 15px;box-sizing: border-box;font-size: 16px;white-space: pre-line;line-height: 30px;color: rgb(74, 74, 74);font-family: Avenir, -apple-system-font, 微软雅黑, sans-serif;"},"namespaceURI":"http://www.w3.org/1999/xhtml"},"node",{"tagName":"span","attributes":{"style":"font-size: 14px;"},"namespaceURI":"http://www.w3.org/1999/xhtml"}]'
+              >✎&nbsp;</span
+            ></span
+          ><span leaf="">第一章 引言</span>
+        </p>
+        <p>
+          <span leaf=""
+            >介绍语言模型在音乐信息检索（MIR）领域的研究背景与发展脉络。回顾早期基于监督分类的音乐标注与检索方法，分析其固定词汇表、独热编码等局限性。概述本教程的整体框架：从语言模型基础出发，依次探索音乐描述、检索与生成三大方向。同时展示语言模型如何推动音乐理解从简单分类走向自然语言交互。</span
+          >
+        </p>
+        <p>
+          <span
+            ><span
+              leaf=""
+              data-pm-slice='1 1 ["para",{"tagName":"p","attributes":{"style":"margin-top: 15px;margin-bottom: 15px;box-sizing: border-box;font-size: 16px;white-space: pre-line;line-height: 30px;color: rgb(74, 74, 74);font-family: Avenir, -apple-system-font, 微软雅黑, sans-serif;"},"namespaceURI":"http://www.w3.org/1999/xhtml"},"node",{"tagName":"span","attributes":{"style":"font-size: 14px;"},"namespaceURI":"http://www.w3.org/1999/xhtml"}]'
+              >✎&nbsp;</span
+            ></span
+          ><span leaf="">第二章 语言模型概述</span>
+        </p>
+        <p>
+          <span leaf=""
+            >系统介绍语言模型的核心概念，包括分词策略（BPE、SentencePiece）、掩码语言模型（BERT）和自回归语言模型（GPT）等范式。深入讲解将非文本输入融入语言模型的多种条件化方法：自适应调制、通道拼接、前缀条件化和交叉注意力机制。梳理迁移学习、零样本推理、缩放定律、RLHF
+            对齐、检索增强生成（RAG）、工具调用及多模态编解码器等前沿进展。同时讨论幻觉、偏见、计算成本、上下文长度限制等尚未解决的挑战。</span
+          >
+        </p>
+        <p>
+          <span
+            ><span
+              leaf=""
+              data-pm-slice='1 1 ["para",{"tagName":"p","attributes":{"style":"margin-top: 15px;margin-bottom: 15px;box-sizing: border-box;font-size: 16px;white-space: pre-line;line-height: 30px;color: rgb(74, 74, 74);font-family: Avenir, -apple-system-font, 微软雅黑, sans-serif;"},"namespaceURI":"http://www.w3.org/1999/xhtml"},"node",{"tagName":"span","attributes":{"style":"font-size: 14px;"},"namespaceURI":"http://www.w3.org/1999/xhtml"}]'
+              >✎&nbsp;</span
+            ></span
+          ><span leaf="">第三章 音乐描述</span>
+        </p>
+        <p>
+          <span leaf=""
+            >涵盖从传统音乐分类（流派、乐器、情绪标签）到自然语言描述生成（音乐字幕）的完整任务谱系，并延伸至音乐问答和对话式描述等新兴交互范式。对比编码器-解码器架构与适配大语言模型（LLM）两大主流建模方案的优劣，附带详细的模型对照表。介绍BLEU、METEOR、BERT-Score
+            等自动评估指标及其局限性，以及 MuChoMusic、OpenMU
+            等专为音乐理解设计的新基准。提供基于真实数据集的代码实践环节。</span
+          >
+        </p>
+        <p>
+          <span
+            ><span
+              leaf=""
+              data-pm-slice='1 1 ["para",{"tagName":"p","attributes":{"style":"margin-top: 15px;margin-bottom: 15px;box-sizing: border-box;font-size: 16px;white-space: pre-line;line-height: 30px;color: rgb(74, 74, 74);font-family: Avenir, -apple-system-font, 微软雅黑, sans-serif;"},"namespaceURI":"http://www.w3.org/1999/xhtml"},"node",{"tagName":"span","attributes":{"style":"font-size: 14px;"},"namespaceURI":"http://www.w3.org/1999/xhtml"}]'
+              >✎&nbsp;</span
+            ></span
+          ><span leaf="">第四章 文本到音乐检索</span>
+        </p>
+        <p>
+          <span leaf=""
+            >从基于分类的布尔检索出发，引出词汇表外（OOV）问题，进而介绍音频-文本联合嵌入这一核心解决方案。详细讲解多模态度量学习中的三元组损失与对比损失，以及从静态词嵌入（GloVe）到上下文化表示（BERT/RoBERTa）的演进。讨论当前面临的三大挑战：查询与描述的分布偏差、训练数据局限于内容属性而忽略文化与元数据维度、单轮检索无法保持上下文。展望对话式音乐检索如何通过多轮交互和用户反馈实现更</span
+          ><span leaf="">自然的搜索体验。</span>
+        </p>
+        <p>
+          <span
+            ><span
+              leaf=""
+              data-pm-slice='1 1 ["para",{"tagName":"p","attributes":{"style":"margin-top: 15px;margin-bottom: 15px;box-sizing: border-box;font-size: 16px;white-space: pre-line;line-height: 30px;color: rgb(74, 74, 74);font-family: Avenir, -apple-system-font, 微软雅黑, sans-serif;"},"namespaceURI":"http://www.w3.org/1999/xhtml"},"node",{"tagName":"span","attributes":{"style":"font-size: 14px;"},"namespaceURI":"http://www.w3.org/1999/xhtml"}]'
+              >✎&nbsp;</span
+            ></span
+          ><span leaf="">第五章 文本到音乐生成</span>
+        </p>
+        <p>
+          <span leaf=""
+            >回顾从算法作曲到神经音频合成的发展历程，聚焦文本到音乐生成的两大技术路线。深入剖析
+            MusicGen 的自回归方案：利用 Encodec 将音频离散化为 token，再通过
+            Transformer
+            逐步生成。对照介绍扩散模型方案的数学基础（SDE、分数函数）、音频表示策略（波形、梅尔频谱、潜空间）以及
+            U-Net 与 DiT 架构。涵盖主观评估（MOS、MUSHRA
+            听力测试）和客观评估（FAD、CLAP
+            Score）等完整的评价体系，并提供代码实践。</span
+          >
+        </p>
+        <p>
+          <span
+            ><span
+              leaf=""
+              data-pm-slice='1 1 ["para",{"tagName":"p","attributes":{"style":"margin-top: 15px;margin-bottom: 15px;box-sizing: border-box;font-size: 16px;white-space: pre-line;line-height: 30px;color: rgb(74, 74, 74);font-family: Avenir, -apple-system-font, 微软雅黑, sans-serif;"},"namespaceURI":"http://www.w3.org/1999/xhtml"},"node",{"tagName":"span","attributes":{"style":"font-size: 14px;"},"namespaceURI":"http://www.w3.org/1999/xhtml"}]'
+              >✎&nbsp;</span
+            ></span
+          ><span leaf="">第六章 总结</span>
+        </p>
+        <p>
+          <span leaf=""
+            >总结全教程的核心知识脉络，回顾从监督分类到大语言模型驱动的范式演进。探讨超越文本控制的未来方向：音频到音频的控制（伴奏生成、音色迁移、迭代编辑）以及基于强度、旋律、和弦等抽象音乐属性的精细化控制。指出文本作为控制媒介在表达细粒度音乐细节方面的固有局限，展望更直觉化的音乐创作交互方式。</span
+          ><span
+            ><span leaf=""><br /></span
+          ></span>
+        </p>
+        <hr />
+        <h3><span leaf="">『网页配置』</span></h3>
+        <p><span leaf="">为了呈现该教程，GitHub Pages 配置如下：</span></p>
+        <ul>
+          <li>
+            <p>
+              <span leaf=""
+                >部署方式：legacy（经典模式，非 GitHub Actions）</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span leaf="">源分支：gh-pages，根目录 /</span></p>
+          </li>
+          <li>
+            <p>
+              <span leaf=""
+                >站点地址：<a
+                  href="https://beiciliang.github.io/intro2musictech/"
+                  target="_blank"
+                  rel="noopener"
+                  >https://beiciliang.github.io/intro2musictech/</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>
+          <span leaf=""
+            >工作原理：每次向 gh-pages 分支推送新的提交，GitHub
+            会自动触发部署，将该分支根目录下的所有静态文件发布到站点。因为根目录有
+            .nojekyll 文件，GitHub 跳过 Jekyll
+            构建，直接原样部署所有文件（包括以 _ 开头的目录如
+            _static/、_images/）。</span
+          >
+        </p>
+        <p><span leaf="">当前 gh-pages 分支结构：</span></p>
+        <section>
+          <pre
+            data-lang="bash"
+          ><code><span leaf="">gh-pages/</span></code><code><span leaf="">├── .nojekyll &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;<span># 禁用 Jekyll，直接部署静态文件</span></span></code><code><span leaf="">├── index.html &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;<span># 首页，教程卡片列表</span></span></code><code><span leaf="">├── MIR-CC.html &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;<span># marimo 教程的静态导出</span></span></code><code><span leaf="">└── music-language-tutorial/ &nbsp; &nbsp; &nbsp;&nbsp;<span># Jupyter Book 渲染的完整站点</span></span></code><code><span leaf="">&nbsp; &nbsp; ├── intro.html &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;<span># 教程首页</span></span></code><code><span leaf="">&nbsp; &nbsp; ├── introduction/ &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;<span># 第一章</span></span></code><code><span leaf="">&nbsp; &nbsp; ├── lm/ &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;<span># 第二章</span></span></code><code><span leaf="">&nbsp; &nbsp; ├── description/ &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;<span># 第三章</span></span></code><code><span leaf="">&nbsp; &nbsp; ├── retrieval/ &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;<span># 第四章</span></span></code><code><span leaf="">&nbsp; &nbsp; ├── generation/ &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;<span># 第五章</span></span></code><code><span leaf="">&nbsp; &nbsp; ├── conclusion/ &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;<span># 第六章</span></span></code><code><span leaf="">&nbsp; &nbsp; ├── bibliography.html &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;<span># 参考文献</span></span></code><code><span leaf="">&nbsp; &nbsp; ├── _static/ &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;<span># CSS/JS/字体等静态资源</span></span></code><code><span leaf="">&nbsp; &nbsp; └── _images/ &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;<span># 图片资源</span></span></code></pre>
+        </section>
+        <p>
+          <span leaf=""
+            >更新流程：在 main 分支用 Jupyter Book v1 构建 → 切换到 gh-pages →
+            复制构建产物 → 提交并推送 → GitHub 自动部署。</span
+          >
+        </p>
+        <p>
+          <span
+            ><span leaf=""
+              >☞ 如果你想帮助博主更新，欢迎发起Pull Request!</span
+            ></span
+          ><span leaf=""><br /></span>
+        </p>
+        <hr />
+        <p>
+          <span
+            ><span leaf=""
+              >如果还有哪些高质量MIR相关教程值得英译中，欢迎留言！</span
+            ></span
+          >
+        </p>
+        <p>
+          <strong
+            ><span
+              ><span leaf=""
+                >上文回顾：<a
+                  target="_blank"
+                  href="https://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247484015&amp;idx=1&amp;sn=ffb0e282814654db668b9aeaae7070e6&amp;scene=21#wechat_redirect"
+                  textvalue="「MIR-CC」2026年用Claude Code就可以无痛入门音乐科技"
+                  data-itemshowtype="0"
+                  linktype="text"
+                  data-linktype="2"
+                  link-id="3c31"
+                  >「MIR-CC」2026年用Claude Code就可以无痛入门音乐科技</a
+                ></span
+              ><span leaf=""><br /></span></span
+          ></strong>
+        </p>
+        <p>
+          <span
+            ><strong><span leaf="">点</span></strong></span
+          ><strong
+            ><span leaf="">击下方</span
+            ><span><span leaf="">阅读原文</span></span
+            ><span leaf="">可直达教程索引</span></strong
+          >
+        </p>
+        <p>
+          <strong
+            ><span
+              ><span
+                leaf=""
+                data-pm-slice='1 1 ["para",{"tagName":"p","attributes":{"style":"margin-top: 15px;margin-bottom: 15px;box-sizing: border-box;font-size: 16px;white-space: pre-line;color: rgb(74, 74, 74);font-family: Avenir, -apple-system-font, 微软雅黑, sans-serif;line-height: normal;"},"namespaceURI":"http://www.w3.org/1999/xhtml"},"node",{"tagName":"span","attributes":{"style":"box-sizing: border-box; white-space: pre-line; line-height: 30px; color: rgb(74, 74, 74); font-family: Avenir, -apple-system-font, 微软雅黑, sans-serif; font-size: 14px;"},"namespaceURI":"http://www.w3.org/1999/xhtml"}]'
+                ><span textstyle=""
+                  >☞
+                  <a
+                    href="https://beiciliang.github.io/intro2musictech"
+                    target="_blank"
+                    rel="noopener"
+                    >https://beiciliang.github.io/intro2musictech</a
+                  ></span
+                ></span
+              ></span
+            ></strong
+          >
+        </p>
+        <p>
+          <span leaf=""><br /></span>
+        </p>
+        <p><mp-style-type data-value="3"></mp-style-type></p>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/music-recommendation.html
+++ b/articles/music-recommendation.html
@@ -1,0 +1,581 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>「MIR-04」音乐推荐: 努力懂你的预言家 - 无痛入门音乐科技</title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「MIR-04」音乐推荐: 努力懂你的预言家</h1>
+      <div class="meta">2020年3月14日 13:44 · 无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            如何在千万首你从来没听过的歌曲/歌手/歌单中, 挑出最符合你品味的候选?
+            让音乐推荐算法成为你挑歌之路上的专属预言家!
+          </p>
+        </blockquote>
+        <section>
+          <span><strong>♬ 本文为MIR音乐信息检索系列的第8篇文章 ♬</strong></span>
+        </section>
+        <section>
+          <span
+            >首先直观展示一下, QQ音乐9.8版本的推荐页在我手机上的样子,
+            这也是音乐推荐算法主要工作的地方.</span
+          >
+        </section>
+        <p>
+          <img
+            data-original-style=""
+            data-index="2"
+            src="https://mmbiz.qpic.cn/mmbiz_jpg/7CrMia15fFJVEAe7MpmJK8icuEx0H2hNV00IBhzIzibpRYhiaA3rWmX72Eq8hzicO0Q4gqGM9LOYiaG3lcPPa1Qk2OIg/640"
+            _width="677px"
+            alt="Image"
+            data-report-img-idx="0"
+          />
+        </p>
+        <section>
+          <span
+            >这里每日都会更新专属于我的推荐歌曲即"每日30首",
+            如果我只想随意听听歌就像背景音乐一样一直播放,
+            那不妨点开同样根据我口味定制的"个性电台".&nbsp;此外还有更多为我推荐的歌单与视频,&nbsp;如果一直往下翻可以无限加载:</span
+          >
+        </section>
+        <section>
+          <span
+            >音乐推荐系统动真格儿地讲起来, 那就是一本书.
+            本文依然本着无痛入门的科普目的, 将大致讲解：</span
+          ><br />
+        </section>
+        <ul>
+          <li>
+            <section><span>经典的协同过滤&nbsp;</span></section>
+          </li>
+          <li>
+            <section>
+              <span>完全基于音频信号的推荐<br /></span>
+            </section>
+          </li>
+          <li>
+            <section>
+              <span>万物皆可embedding<br /></span>
+            </section>
+          </li>
+        </ul>
+        <hr />
+        <h3>『经典的协同过滤』</h3>
+        <p>
+          <span
+            >协同过滤 (简称CF)
+            大概是最常见的推荐算法了,&nbsp;它和我们首先能想到的推荐逻辑一样:
+            "用户1和用户2是因为音乐结缘的好朋友,
+            两个人有很相似的听歌历史(都听过歌曲A和B),
+            当用户2给1推荐1没听过的新歌C, 用户1应该会喜欢哒!&nbsp;"
+            这就是所谓的User-based CF.</span
+          >
+        </p>
+        <p>
+          <img
+            data-croporisrc="https://mmbiz.qlogo.cn/mmbiz_png/7CrMia15fFJVEAe7MpmJK8icuEx0H2hNV05xJ4ic3uxAEDLaicYVicZSwrnBnwwXJMW25dZCfMichianXltoJHicw5gceQ/0?wx_fmt=png"
+            data-cropx1="0"
+            data-cropx2="1280"
+            data-cropy1="42.076124567474054"
+            data-cropy2="535.9169550173011"
+            data-original-style="width: 578px;height: 223px;"
+            data-index="3"
+            src="https://mmbiz.qpic.cn/mmbiz_jpg/7CrMia15fFJVEAe7MpmJK8icuEx0H2hNV0iaCNLibXVDn6d9wkiaOUdomh8umuTrUyvibBy8Bcic2icAicbGl5hEqMibd9oQ/640"
+            _width="578px"
+            alt="Image"
+          /><span>上图来自Medium</span>
+        </p>
+        <p>
+          <span
+            >而另外一种Item-based&nbsp;CF则是通过物品之间的相似进行推荐:</span
+          >
+        </p>
+        <p>
+          <img
+            data-croporisrc="https://mmbiz.qlogo.cn/mmbiz_png/7CrMia15fFJVEAe7MpmJK8icuEx0H2hNV07TVkA3M3lSCczibZboibTPOibjBHgic7njgkreoOgf9eEL3G3N1pnpszEw/0?wx_fmt=png"
+            data-cropx1="0"
+            data-cropx2="664.5519031141869"
+            data-cropy1="0"
+            data-cropy2="403.8321799307958"
+            data-original-style="width: 469px;height: 285px;"
+            data-index="4"
+            src="https://mmbiz.qpic.cn/mmbiz_jpg/7CrMia15fFJVEAe7MpmJK8icuEx0H2hNV0iciciaZeAcGR34mjVF6sE2gGicOh6WrWO7UKnc67Hpqzlib4XREic8lRbYTQ/640"
+            _width="469px"
+            alt="Image"
+          />
+        </p>
+        <p><span>上图来自Medium</span></p>
+        <p>
+          <span
+            >那么问题来了, 在音乐这个场景中, 如何判断不同歌曲之间是相似的?
+            又如何判断不同听歌群众之间的相似?&nbsp;先来解决歌曲相似的问题,&nbsp;直接抛出Spotify的解决方案:
+            <strong
+              >用自然语言处理中word2vec的方法,&nbsp;<span>从海量歌单入手</span>实现song2vec.</strong
+            ></span
+          >
+        </p>
+        <p>
+          <span
+            >在文本信息中, 语义相似或有潜在联系的词语,
+            会更大概率地出现在同一个段落,
+            因此用海量文本信息训练出来的自然语言处理模型,
+            其中隐层的权重就可以隐晦地表示一个词语, 实现word2vec. 比如下图中,
+            在训练这个大模型时, 输入端用了"后巷", 输出端用了"小", "暗", "后边",
+            "the"(顿时不知道咋翻译)这些与"后巷"在同个自然段出现的词语.
+            以后我们判断"后巷"与"大街"有多相似时, 可以直接用下图中的模型权重W1,
+            与输入"大街"时模型对应的W1', 互相比较.</span
+          >
+        </p>
+        <p>
+          <img
+            data-original-style=""
+            data-index="5"
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJVEAe7MpmJK8icuEx0H2hNV05jvN9aYuGD0j44eYh1ib9ae7W9SpaDNQrBF85wia9KEgOxfEgibZa5OPA/640"
+            _width="677px"
+            alt="Image"
+          /><span>上图来自Medium</span>
+        </p>
+        <p>
+          <span
+            >同理, 音乐平台上海量用户创建了海量的歌单,
+            这些歌单里涵盖的歌曲一般都有很强的相关性, 也许是流派相似,
+            也许是同个时代的热门, 等等等等. 那我们也可以像word2vec一样,
+            实现song2vec:</span
+          >
+        </p>
+        <p>
+          <img
+            data-croporisrc="https://mmbiz.qlogo.cn/mmbiz_png/7CrMia15fFJVEAe7MpmJK8icuEx0H2hNV0h0BLHH3RznvBrAurqXQQIKS5PqdtpjghR6Fx4c195VvkrT98DjMvag/0?wx_fmt=png"
+            data-cropx1="0"
+            data-cropx2="1280"
+            data-cropy1="57.57785467128027"
+            data-cropy2="628.9273356401384"
+            data-original-style="width: 578px;height: 258px;"
+            data-index="6"
+            src="https://mmbiz.qpic.cn/mmbiz_jpg/7CrMia15fFJVEAe7MpmJK8icuEx0H2hNV0kDTby6RNOoWcz4lE82wqM5dj5HicEDolJoEMysDT1RZIb1SZQh40oBA/640"
+            _width="578px"
+            alt="Image"
+          /><span>上图来自Medium</span>
+        </p>
+        <p>
+          <span
+            >此时此刻,&nbsp;每一首出现在歌单里的歌曲都能分别被表示成一个向量,
+            向量之间的相似性可通过欧氏距离, cosine距离, 或其他各种距离去计算,
+            或者交给开源的"ANNOY".<br
+          /></span>
+        </p>
+        <p>
+          <span
+            >而用户之间的相似性,
+            则可以根据他们的听歌历史对应的向量去计算.&nbsp;比如下图中用户A和B分别听过4首歌曲,
+            每个歌曲通过song2vec得到的向量用简单的2个数值表示一下:</span
+          >
+        </p>
+        <p>
+          <img
+            data-croporisrc="https://mmbiz.qlogo.cn/mmbiz_png/7CrMia15fFJVEAe7MpmJK8icuEx0H2hNV0NUibHWkLpTJ0vDhfUbMDBt9nNDlKBiahm4T7ryAeicDXwyyZMibaXMaGeQ/0?wx_fmt=png"
+            data-cropx1="28.78892733564014"
+            data-cropx2="1280"
+            data-cropy1="179.3771626297578"
+            data-cropy2="604.5674740484429"
+            data-original-style="width: 565px;height: 192px;"
+            data-index="7"
+            src="https://mmbiz.qpic.cn/mmbiz_jpg/7CrMia15fFJVEAe7MpmJK8icuEx0H2hNV0kPXJuOGl6AzpNcVxPr5pzR1CoErWk4BTxKmmficUkwyB8b3U2pXic1gw/640"
+            _width="565px"
+            alt="Image"
+          />
+        </p>
+        <p>
+          <span
+            >那么将歌曲的向量加和取平均, 就能得到代表用户A和B的向量, 分别是(2.5,
+            2.5)和(3.5, 3.5).</span
+          >
+        </p>
+        <p>
+          <img
+            data-croporisrc="https://mmbiz.qlogo.cn/mmbiz_png/7CrMia15fFJVEAe7MpmJK8icuEx0H2hNV0I1EHESm7g7KgdMD4DEmV0zCBa7S8BDTd6OqBPQ8oJfV9icCANq4SP4A/0?wx_fmt=png"
+            data-cropx1="0"
+            data-cropx2="1280"
+            data-cropy1="267.95847750865056"
+            data-cropy2="611.2110726643599"
+            data-original-style="width: 578px;height: 155px;"
+            data-index="8"
+            src="https://mmbiz.qpic.cn/mmbiz_jpg/7CrMia15fFJVEAe7MpmJK8icuEx0H2hNV0fTg3GzQTeAiaxLABuwaR9Ir8fFYvw0dcDVFGQgrbIWh3k5u4R9ziafnA/640"
+            _width="578px"
+            alt="Image"
+          />
+        </p>
+        <p>
+          <span
+            >接下来用户A和B到底多相似, 就又回到计算向量之间的距离问题了.</span
+          >
+        </p>
+        <p>
+          <span
+            ><span>☞ ANNOY:&nbsp;</span
+            ><span
+              ><a
+                href="https://github.com/spotify/annoy"
+                target="_blank"
+                rel="noopener"
+                >https://github.com/spotify/annoy</a
+              ></span
+            ></span
+          ><br />
+        </p>
+        <p>
+          <span
+            >说到这里, 不知道大家是否有发现协同过滤的弊端? 那就是"冷启动"问题,
+            即song2vec只能将在歌单里出现过的歌曲变成向量,&nbsp;如果有太冷门的歌曲,
+            从来没被任何用户放在歌单里,
+            或者一首刚刚发布的新歌,&nbsp;岂不是没有对应向量的存在?</span
+          >
+        </p>
+        <p>
+          <span
+            >基于内容的推荐就是解决冷启动的一剂良药,&nbsp;而海量的音乐内容除了有歌词,
+            语种, 发行时间等信息之外,
+            音乐本身最最本质的音频信号也可以用于推荐.<br
+          /></span>
+        </p>
+        <hr />
+        <h3>『完全基于音频信号的推荐』</h3>
+        <p>
+          <span
+            >已经有不少工作尝试将我们之前"音频特征小全"里提到的各种特征,
+            加入进推荐系统里, 然而收效甚微.&nbsp;直到2013年NeurIPS上的一篇"Deep
+            content-based music recommendation"横空出世, 这是一作</span
+          ><span
+            >Aäron van den Oord在Spotify实习时的成果,
+            他现在在Google&nbsp;DeepMind工作,&nbsp;WavNet也是他的主要成就.&nbsp;这篇文章和对应的博客也已经被许多人翻译成了中文</span
+          ><span>.</span>
+        </p>
+        <p>
+          <span
+            >文章里并没有用到多炫酷的深度学习模型,&nbsp;音频预处理也是常见的波形转变为2D的时频谱,
+            再将其作为输入.
+            训练好的模型可以实现将一首歌表示成一个40维的向量:</span
+          >
+        </p>
+        <p>
+          <img
+            data-original-style=""
+            data-index="9"
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJVEAe7MpmJK8icuEx0H2hNV0DhGTwFV9K0UTeVzQJ4BzziadO8zOxokLvcKjwouOEyWF1PowPH4Yzmg/640"
+            _width="677px"
+            alt="Image"
+          />
+        </p>
+        <p>
+          <span
+            >最关键的点就在于,&nbsp;在训练模型的过程中用到的40维是什么?
+            从哪儿来的? 答案是<strong
+              >把"各个用户对各个歌曲收听次数量"的矩阵进行分解后得到的表示各个歌曲的40维潜在因子(latent
+              factors),</strong
+            >&nbsp;也就是下图里的"y_i".</span
+          >
+        </p>
+        <p>
+          <img
+            data-original-style=""
+            data-index="10"
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJVEAe7MpmJK8icuEx0H2hNV01sibpTA06hC3AI0bORCX11ZqBW89z1KSRNa9qgnQ2ZnaCiaaoccibfTpg/640"
+            _width="677px"
+            alt="Image"
+          />
+        </p>
+        <p>
+          <span
+            >论文中矩阵分解用到的是WMF (weighted matrix factorization,
+            详见后文方参考文献),
+            设定超参数为40即可分别得到表示用户的和表示歌曲的40维潜在因子.</span
+          >
+        </p>
+        <p>
+          <span
+            >我们单独把"歌曲i的40维潜在因子y_i"抽出来, 在训练深度模型时,
+            将该歌曲的时频谱作为输入,&nbsp;设定模型输出y'_i也是40维,
+            训练过程中使y'_i不断地去接近y_i的值.&nbsp;对于其他训练集中的歌曲也是同样操作,&nbsp;最后深度学习模型的参数<span>θ</span>可以做到使所有y'_i和y_i之间的MSE差距最小:</span
+          >
+        </p>
+        <p>
+          <img
+            data-original-style=""
+            data-index="11"
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJVEAe7MpmJK8icuEx0H2hNV0eNBQwSSscVG2Vd8cDOwKyWnWjt2Zmh2oVMwicE0fDAHTDIPtl7tVauw/640"
+            _width="677px"
+            alt="Image"
+          />
+        </p>
+        <p>
+          <span
+            >当来了一首全新的歌时, 将其时频谱输入到刚训练好的模型中,
+            就能预测输出一个表示这首歌的40维潜在因子,&nbsp;将它与原来分解出来的用户u的40维潜在因子x_u相乘,
+            就能估算出用户u将来会收听这首新歌多少次了! 若预测到收听次数越高,
+            把这首新歌推荐给用户u的可能性就越大.<br
+          /></span>
+        </p>
+        <p>
+          <span
+            >当然也可以把深度学习模型输出的40维潜在因子, 像上文的song2vec一样,
+            用于相似歌曲的召回!</span
+          >
+        </p>
+        <p>
+          <span>☞ 原论文链接:&nbsp;</span
+          ><span
+            ><a
+              href="https://papers.nips.cc/paper/5004-deep-content-based-music-recommendation"
+              target="_blank"
+              rel="noopener"
+              >https://papers.nips.cc/paper/5004-deep-content-based-music-recommendation</a
+            ></span
+          ><br />
+        </p>
+        <p>
+          <span
+            ><span>☞ WMF参考文献: </span
+            ><span
+              >Yifan Hu, Yehuda Koren, and Chris Volinsky. Collaborative
+              filtering for implicit feedback datasets. In Proceedings of the
+              2008 Eighth IEEE International Conference on Data Mining,
+              2008.</span
+            ></span
+          >
+        </p>
+        <hr />
+        <h3>『万物皆可embedding』</h3>
+        <p>
+          <span
+            >除了协同过滤和基于内容的推荐,
+            更厉害的音乐推荐系统还应该做到为用户设身处地的进行推荐,&nbsp;即contex-aware.
+            比如我在跑步的时候要是一直被推荐到瑜伽歌曲, 那就不太合适,
+            但这里又会涉及到app与用户隐私之间的问题.</span
+          ><br />
+        </p>
+        <p>
+          <span
+            >目前业界多为混合推荐,
+            各种策略均有.&nbsp;所用特征如果一个值无法清晰表示,
+            不如变成像song2vec或潜在因子那样的embedding.
+            关于音乐推荐系统的更多前沿学术内容可以参考Markus Schedl和Peter
+            Knees发表过的文章.</span
+          >
+        </p>
+        <p>
+          <span>☞ </span
+          ><span
+            >"Deep Learning in Music Recommendation Systems." Frontiers in
+            Applied Mathematics and Statistics 5 (2019): 44.&nbsp;</span
+          >
+        </p>
+        <hr />
+        <p>
+          <span
+            >最后,
+            音乐推荐更离不开用户的反馈,&nbsp;当你在app上对我们推荐歌曲的喜恶越明确,
+            算法就越会贴合你的口味.&nbsp;</span
+          >
+        </p>
+        <p>
+          <span
+            >分别用"完全基于音频的潜在因子"和"<span>协同过滤里word2vec"</span>召回的相似歌曲,
+            有什么微妙的不同, 欢迎大家扫码去我的QQ音乐歌单中感受一下 (</span
+          ><span
+            >注: 歌单中均以第一首歌曲为起源, 第2&amp;3首用了42维audio embedding,
+            第3&amp;4首用了84维, 最后两首用word2vec进行相似歌曲召回).</span
+          >
+        </p>
+        <p>
+          <img
+            data-original-style="width: 100%;height: auto;"
+            data-index="12"
+            src="https://mmbiz.qpic.cn/mmbiz_jpg/7CrMia15fFJVEAe7MpmJK8icuEx0H2hNV0XEqTk2LVxncseBlzibzyEKdXFqqZMrxANDNYxibJuAk2mrqqaEkYEhAw/640"
+            _width="100%"
+            alt="Image"
+          />
+        </p>
+        <p>
+          <img
+            data-original-style=""
+            data-index="13"
+            src="https://mmbiz.qpic.cn/mmbiz_jpg/7CrMia15fFJVEAe7MpmJK8icuEx0H2hNV0SNpaxicP2zNqVSlsqib8LKvsZAibPd3IPEcKAuib5vKT3Wol70fNBR2pYA/640"
+            _width="677px"
+            alt="Image"
+          />
+        </p>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/music-tech-2018.html
+++ b/articles/music-tech-2018.html
@@ -1,0 +1,787 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>「INFO」2018年度那些亮眼的音乐科技成就 - 无痛入门音乐科技</title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「INFO」2018年度那些亮眼的音乐科技成就</h1>
+      <div class="meta">无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            简单盘点一下，2018年音乐科技在算法层面令博主印象深刻的学术研究！个人眼界有限，如有勘误或遗漏，还请包涵！
+          </p>
+        </blockquote>
+        <p>
+          <span
+            >过去的一年里，深度学习在音乐信息检索与音乐智能创作上的应用可谓层出不穷，同时成功吸引了工业界的注意力。本文将在以下几个方面做简要总结：</span
+          >
+        </p>
+        <ul>
+          <li>
+            <p><span>乐音估计：音高(pitch)，和弦(chord)</span></p>
+          </li>
+          <li>
+            <p><span>节奏追踪：重拍(downbeat)，节奏(tempo)</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                >与人相关的识别：演奏技巧(playing technique)，人声(singing
+                voice)，情绪(mood)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>声源分离(source separation)</span></p>
+          </li>
+          <li>
+            <p><span>自动标注(auto-tagging)</span></p>
+          </li>
+          <li>
+            <p><span>智能生成(intelligent generation)</span></p>
+          </li>
+          <li>
+            <p><span>非西方音乐的研究(world music)</span></p>
+          </li>
+          <li>
+            <p><span>博主所在C4DM科研组的其他亮点</span></p>
+          </li>
+        </ul>
+        <hr />
+        <h3>『乐音估计』</h3>
+        <p><strong>♬ 音高 ♬</strong></p>
+        <p>
+          ☞ 博主一直崇拜的女神Rachel M.
+          Bittner今年从纽约大学MARL科研组博士毕业了！她的课题就是从最底层的数字信号处理到目前最流行的深度卷积神经网络，全方位地研究基频估计，论文题目是Data-Driven
+          Fundamental Frequency Estimation。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://drive.google.com/file/d/1Lf6G5yaqi-JwpwOFN99p6HMr4AvefSzc/view"
+              target="_blank"
+              rel="noopener"
+              >https://drive.google.com/file/d/1Lf6G5yaqi-JwpwOFN99p6HMr4AvefSzc/view</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞
+          另外MARL科研组在18年的一个颇有名气的成就，就是基于单旋律的音高识别，即Jong
+          Wook Kim等人提出的CREPE: A Convolutional Representation for Pitch
+          Estimation。除了论文，还有非常不错的网页应用小样！
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://arxiv.org/pdf/1802.06182.pdf"
+              target="_blank"
+              rel="noopener"
+              >https://arxiv.org/pdf/1802.06182.pdf</a
+            ></span
+          >
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://marl.github.io/crepe/"
+              target="_blank"
+              rel="noopener"
+              >https://marl.github.io/crepe/</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞
+          对于多旋律的音高估计，很大一部分的研究都是基于钢琴这个乐器的音频进行评价的，目前效果最好的就是由Google
+          Magenta提出的Onsets and Frames: Dual-Objective Piano
+          Transcription。又是一个自带网页应用小样的算法展示。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://magenta.tensorflow.org/onsets-frames"
+              target="_blank"
+              rel="noopener"
+              >https://magenta.tensorflow.org/onsets-frames</a
+            ></span
+          >
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://piano-scribe.glitch.me/"
+              target="_blank"
+              rel="noopener"
+              >https://piano-scribe.glitch.me/</a
+            ></span
+          >
+        </p>
+        <p><strong>♬ 和弦 ♬</strong></p>
+        <p>
+          ☞ JKU的Filip
+          Korzeniowski小哥通过将声学模型、语言模型和时长模型融合进RNN，进行大小和弦等25类和弦的识别，在今年的EUSIPCO、ICASSP和ISMIR会议上都能见到他展示成果时长发飘飘的身影。下方链接为ISMIR上的文章Improved
+          Chord Recognition by Combining Duration and Harmonic Language Models。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://arxiv.org/pdf/1808.05335.pdf"
+              target="_blank"
+              rel="noopener"
+              >https://arxiv.org/pdf/1808.05335.pdf</a
+            ></span
+          >
+        </p>
+        <hr />
+        <h3>『节奏追踪』</h3>
+        <p>
+          ☞
+          通过比较RNN和CRNN在重拍检测上的性能，分析针对于这类检测问题最佳的深度学习模型设置方案：Analysis
+          of common design choices in deep learning systems for downbeat
+          tracking。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://bmcfee.github.io/papers/ismir2018_downbeat.pdf"
+              target="_blank"
+              rel="noopener"
+              >https://bmcfee.github.io/papers/ismir2018_downbeat.pdf</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞
+          在全局层面衡量一首歌曲的节奏，可以通过用CNN估计局部的节奏后再推断全局节奏，这篇文章用更简单的模型实现了其他复杂模型的性能，数据库和代码的开源链接也都包含在文章里A
+          single-step approach to musical tempo estimation using a convolutional
+          neural network。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://www.researchgate.net/profile/Hendrik_Schreiber/publication/328028453_A_Single-Step_Approach_to_Musical_Tempo_Estimation_Using_a_Convolutional_Neural_Network/links/5bb3933692851ca9ed349cf7/A-Single-Step-Approach-to-Musical-Tempo-Estimation-Using-a-Convolutional-Neural-Network.pdf"
+              target="_blank"
+              rel="noopener"
+              >https://www.researchgate.net/profile/Hendrik_Schreiber/publication/328028453</a
+            ></span
+          >
+        </p>
+        <hr />
+        <h3>『与人相关的识别』</h3>
+        <p><strong>♬ 演奏技巧 ♬</strong></p>
+        <p>
+          ☞ Vincent
+          Lostanlen提出演奏技巧的识别是从乐器识别中衍生的下一个里程碑般的任务，对于如何理解“演奏技巧”以及都有哪些成果，可以参考他的文章Extended
+          playing techniques: The next milestone in musical instrument
+          recognition。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://arxiv.org/pdf/1808.09730.pdf"
+              target="_blank"
+              rel="noopener"
+              >https://arxiv.org/pdf/1808.09730.pdf</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞ 目前基于鼓的研究是相对完整的，佐治亚理工的Chih-Wei
+          Wu今年成功拿到了关于鼓类音乐信息检索的博士学位，并发表了这篇高质量综述A
+          Review of Automatic Drum Transcription。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://dl.acm.org/citation.cfm?id=3232299"
+              target="_blank"
+              rel="noopener"
+              >https://dl.acm.org/citation.cfm?id=3232299</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞ 针对于吉他，往年有一些论文，但在今年最醒目的还是Qingyang
+          Xi等人公布的新数据库。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://github.com/marl/GuitarSet"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/marl/GuitarSet</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞
+          这里插播一条广告，博主本人也是做这个方向的，不过是针对于钢琴演奏中的踏板技巧。既有设计硬件直接捕获，也有结合钢琴声学的信号处理，目前也走上了深度学习的道路。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://beiciliang.weebly.com/blog/deep-pedal"
+              target="_blank"
+              rel="noopener"
+              >https://beiciliang.weebly.com/blog/deep-pedal</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞ 组里的其他同学也有在做基于其他乐器的演奏技巧识别，Changhong
+          Wang的研究针对于中国竹笛，Yudong Zhao则是针对于小提琴。
+        </p>
+        <p><strong>♬ 人声 ♬</strong></p>
+        <p>
+          ☞ 这里是指检测出一首歌中有哪些地方包含了人声，Kyungyun
+          Lee比较分析了经典算法并提出了许多建设性意见：Revisiting Singing Voice
+          Detection: A quantitative review and the future outlook。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://arxiv.org/pdf/1806.01180.pdf"
+              target="_blank"
+              rel="noopener"
+              >https://arxiv.org/pdf/1806.01180.pdf</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞ 一个新量级的数据库也在今年提出，DALI: a large Dataset of
+          synchronized Audio, LyrIcs and notes, automatically created using
+          teacher-student machine learning paradigm
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://github.com/gabolsgabs/DALI"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/gabolsgabs/DALI</a
+            ></span
+          >
+        </p>
+        <p><strong>♬ 情绪 ♬</strong></p>
+        <p>
+          ☞
+          音乐中的情绪识别一直是个难点，但这篇文章里考虑了同时利用音频信号和歌词信息：Music
+          Mood Detection Based On Audio And Lyrics With Deep Neural Net。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://arxiv.org/pdf/1809.07276.pdf"
+              target="_blank"
+              rel="noopener"
+              >https://arxiv.org/pdf/1809.07276.pdf</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞
+          现有的音乐情绪研究大多基于MSD数据库，其中每个音频对应一种情绪标签。实际上人的情绪在一首歌里并不是一成不变的，我们组里的Simin
+          Yang就在针对这种live情境下的音乐情绪进行研究。
+        </p>
+        <hr />
+        <h3>『声源分离』</h3>
+        <p>
+          在以上任务中，一种常见的提升识别准确度的预处理办法就是声源分离，今年第14届LVA
+          ICA会议召开后更是涌现了好多论文，在之后的论文SiSEC 2018: State of the
+          art in musical audio source separation - subjective selection of the
+          best algorithm中就召集了LVA
+          ICA的参会人员，对6种性能较突出的算法分离出的音乐结果进行主观评价，看看大家目前对哪一种算法的效果更满意。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://hal.inria.fr/hal-01945362/document"
+              target="_blank"
+              rel="noopener"
+              >https://hal.inria.fr/hal-01945362/document</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞ 不得不提其中一种算法是我们组Daniel Stoller的成果Wave-U-Net: A
+          Multi-Scale Neural Network for End-to-End Audio Source Separation。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://github.com/f90/Wave-U-Net"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/f90/Wave-U-Net</a
+            ></span
+          >
+        </p>
+        <hr />
+        <h3>『自动标注』</h3>
+        <p>
+          ☞ 首先是这个领域的名人，也是我的亲师哥Keunwoo
+          Choi博士毕业，毕业论文为Deep Neural Networks for Music Tagging。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://qmro.qmul.ac.uk/xmlui/bitstream/handle/123456789/46029/CHOI_Keunwoo_PhD_Final_190918.pdf?sequence=1"
+              target="_blank"
+              rel="noopener"
+              >https://qmro.qmul.ac.uk/xmlui/bitstream/handle/123456789/46029/CHOI_Keunwoo_PhD_Final_190918.pdf</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞ 今年ISMIR上的最佳论文颁给了UPF大学MTG科研组Jordi Pons的End-to-end
+          Learning for Music Audio Tagging at Scale。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://arxiv.org/pdf/1711.02520.pdf"
+              target="_blank"
+              rel="noopener"
+              >https://arxiv.org/pdf/1711.02520.pdf</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞
+          DCASE竞赛中任务2里的挑战也是用的MTG开发的freesound数据库，在该任务中韩国Young
+          Jeong等人提出的算法取得了最高的性能。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://www.researchgate.net/profile/Hyungui_Lim/publication/328927908_Audio_Tagging_System_Using_Densely_Connected_Convolutional_Networks/links/5bebdaff299bf1124fd11f77/Audio-Tagging-System-Using-Densely-Connected-Convolutional-Networks.pdf"
+              target="_blank"
+              rel="noopener"
+              >https://www.researchgate.net/profile/Hyungui_Lim/publication/328927908</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞ 值得注意的是萨利大学的Qiuqiang
+          Kong和许多国内的学者们在DCASE此项任务中也是表现不凡。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="http://dcase.community/challenge2018/task-general-purpose-audio-tagging"
+              target="_blank"
+              rel="noopener"
+              >http://dcase.community/challenge2018/task-general-purpose-audio-tagging</a
+            ></span
+          >
+        </p>
+        <hr />
+        <h3>『智能创新』</h3>
+        <p>
+          ☞
+          讲到这儿就不得不说智能作曲了，我一直自诩耳朵刁钻所以保持一个“怀疑者”的姿态，直到我最近看到Google
+          Magenta里Cheng-Zhi Anna Huang等人做出的Music Transformer: Generating
+          Music with Long-Term Structure。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://magenta.tensorflow.org/music-transformer"
+              target="_blank"
+              rel="noopener"
+              >https://magenta.tensorflow.org/music-transformer</a
+            ></span
+          >
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://arxiv.org/pdf/1809.04281.pdf"
+              target="_blank"
+              rel="noopener"
+              >https://arxiv.org/pdf/1809.04281.pdf</a
+            ></span
+          >
+        </p>
+        <p><span>➥ 视频小样如下：</span></p>
+        <p>
+          ☞
+          如果你也想训练一个基于钢琴音乐自动生成的深度学习模型，不妨用一用Magenta刚发布的MAESTRO数据库，包含大量MIDI与音频且相互时间轴同步的数据。<br />
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://magenta.tensorflow.org/datasets/maestro"
+              target="_blank"
+              rel="noopener"
+              >https://magenta.tensorflow.org/datasets/maestro</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞
+          除了智能作曲，另外可以利用机器展现创造力的例子是，基于文本内容智能生成电台广播或有声书。比如一段文字是“我正走在寂静的森林里，突然一大群蜜蜂从我脑顶上方飞过”，生成出的音频就需要有“森林”和“蜜蜂”这两个元素，同时要用音效表现“寂静”和“一大群”的环境以及“脑顶上方”的方位和“突然飞过”的动态。我们组的Emmanouil
+          Theofanis Chourdakis就在论文From my pen to your ears: automatic
+          production of radio plays from unstructured story
+          text中做了这样的工作。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://qmro.qmul.ac.uk/xmlui/bitstream/handle/123456789/45984/Chourdakis%20From%20my%20pen%202018%20Published.pdf?sequence=1"
+              target="_blank"
+              rel="noopener"
+              >https://qmro.qmul.ac.uk/xmlui/bitstream/handle/123456789/45984/Chourdakis%20From%20my%20pen%202018%20Published.pdf?sequence=1</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞ 说到音效，智能控制不同音效的参数也是C4DM的一大研究方向。比如Di
+          Sheng就提出了Feature design using audio decomposition for intelligent
+          control of the dynamic range compressor，Marco Martínez提出End-to-end
+          equalization with convolutional neural networks等等。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://ieeexplore.ieee.org/document/8461513"
+              target="_blank"
+              rel="noopener"
+              >https://ieeexplore.ieee.org/document/8461513</a
+            ></span
+          >
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="http://dafx2018.web.ua.pt/papers/DAFx2018_paper_27.pdf"
+              target="_blank"
+              rel="noopener"
+              >http://dafx2018.web.ua.pt/papers/DAFx2018_paper_27.pdf</a
+            ></span
+          >
+        </p>
+        <hr />
+        <h3>『非西方音乐的研究』</h3>
+        <p>这里主要介绍以下三位在今年获得博士学位的朋友们的学术工作：</p>
+        <p>
+          ☞ 我们C4DM组的Maria Panteli对世界音乐的大数据分析：Computational
+          analysis of world music corpora
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://www.eecs.qmul.ac.uk/~simond/phd/MariaPanteli-PhD-Thesis.pdf"
+              target="_blank"
+              rel="noopener"
+              >https://www.eecs.qmul.ac.uk/~simond/phd/MariaPanteli-PhD-Thesis.pdf</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞ UPF大学MTG组Rong Gong对京剧中歌唱发音的自动评价：Automatic
+          Assessment of Singing Voice Pronunciation: A Case Study with Jingju
+          Music
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://compmusic.upf.edu/phd-thesis-rgong"
+              target="_blank"
+              rel="noopener"
+              >https://compmusic.upf.edu/phd-thesis-rgong</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞ UPF大学MTG组Rafael Caro Repetto利用计算机辅助京剧音乐学的分析：The
+          musical dimension of Chinese traditional theatre: An analysis from
+          computer aided musicology
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://compmusic.upf.edu/caro2018thesis"
+              target="_blank"
+              rel="noopener"
+              >https://compmusic.upf.edu/caro2018thesis</a
+            ></span
+          >
+        </p>
+        <hr />
+        <p>
+          <strong><span>博主所在C4DM科研组的其他亮点:&nbsp;</span></strong>
+        </p>
+        <p>
+          五年大项目Fusing Audio and Semantic
+          Technologies进入收尾一年，并在Abbey Road Studios对工业界进行展示：
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="http://www.semanticaudio.ac.uk/"
+              target="_blank"
+              rel="noopener"
+              >http://www.semanticaudio.ac.uk/</a
+            ></span
+          >
+        </p>
+        <p>下属machine listening实验室的年度总结：</p>
+        <p>
+          <span
+            >➥
+            <a
+              href="http://machine-listening.eecs.qmul.ac.uk/2018/12/2018-the-year-in-review/"
+              target="_blank"
+              rel="noopener"
+              >http://machine-listening.eecs.qmul.ac.uk/2018/12/2018-the-year-in-review/</a
+            ></span
+          >
+        </p>
+        <p>
+          我们组每年圣诞前召开的Digital Music Research Network One-day
+          Workshop已经举办到了第13届：
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://www.qmul.ac.uk/dmrn/dmrn13/"
+              target="_blank"
+              rel="noopener"
+              >https://www.qmul.ac.uk/dmrn/dmrn13/</a
+            ></span
+          >
+        </p>
+        <p>联合诸多欧盟院校共同开展的博士培养项目MIPFrontiers于今年开始：</p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://www.upf.edu/web/mip-frontiers"
+              target="_blank"
+              rel="noopener"
+              >https://www.upf.edu/web/mip-frontiers</a
+            ></span
+          >
+        </p>
+        <p>更多关于C4DM的信息请访问官网：</p>
+        <p>
+          <span
+            >➥
+            <a
+              href="http://c4dm.eecs.qmul.ac.uk/"
+              target="_blank"
+              rel="noopener"
+              >http://c4dm.eecs.qmul.ac.uk/</a
+            ></span
+          >
+        </p>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/music-tech-2019.html
+++ b/articles/music-tech-2019.html
@@ -1,0 +1,704 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>「INFO」2019年度那些亮眼的音乐科技成就 - 无痛入门音乐科技</title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「INFO」2019年度那些亮眼的音乐科技成就</h1>
+      <div class="meta">2020年1月12日 08:13 · 无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            <span
+              >简单盘点一下，2019年音乐科技方面令博主印象深刻的学术研究！</span
+            ><span>个人眼界有限，如有勘误或遗漏，还请包涵！</span>
+          </p>
+        </blockquote>
+        <p>
+          <span
+            >过去的一年里，深度学习继续在传统的音乐信息检索任务上做优化，并且开源了许多“已经训练好”的大模型，同时出现了更多高质量的新数据集。</span
+          ><span>本文将在以下几个方面做简要总结：</span>
+        </p>
+        <ul>
+          <li>
+            <p><span>传统任务：音高判定/节拍追踪/和弦识别/翻唱检测</span></p>
+          </li>
+          <li>
+            <p><span>音乐其他方面的数据分析</span></p>
+          </li>
+          <li>
+            <p><span>声源分离：歌曲分离为人声及其伴奏</span></p>
+          </li>
+          <li>
+            <p><span>自动标注：声音事件和音乐标签</span></p>
+          </li>
+          <li>
+            <p><span>智能生成：自动伴奏 </span></p>
+          </li>
+          <li>
+            <p><span>造福大众的新数据集</span></p>
+          </li>
+        </ul>
+        <p>
+          <span
+            >P.S. 往期回顾 -
+            <a
+              target="_blank"
+              href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483768&amp;idx=1&amp;sn=5be59ee8a281e9920399820f09a339ec&amp;chksm=fe0d9fd7c97a16c1aa4e687160944991218d1875d523b272c54143c59e360c4fc10e43700879&amp;scene=21#wechat_redirect"
+              textvalue="2018年的音乐科技年度总结"
+              data-itemshowtype="0"
+              tab="innerlink"
+              data-linktype="2"
+              hasload="1"
+              >2018年的音乐科技年度总结</a
+            ></span
+          >
+        </p>
+        <hr />
+        <h3>『传统任务』</h3>
+        <p>
+          <strong
+            ><strong>♬&nbsp;</strong>音高判定&nbsp;<strong
+              >♬&nbsp;</strong
+            ></strong
+          >
+        </p>
+        <p>
+          ☞ 还记得18年总结里提到的由Jong Wook
+          Kim等人提出的单旋律音高识别CREPE么？一作小哥在19年ISMIR会议上发表了一篇钢琴复音识别的文章，优化了18年总结中提到的Onsets
+          and
+          Frames模型。另外，他也从纽约大学MARL科研组博士毕业了，论文题目是Automatic
+          Music Transcription in the Deep Learning Era。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="http://archives.ismir.net/ismir2019/paper/000081.pdf"
+              target="_blank"
+              rel="noopener"
+              >http://archives.ismir.net/ismir2019/paper/000081.pdf</a
+            ></span
+          >
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://github.com/jongwook/dissertation"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/jongwook/dissertation</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞ Google
+          Research团队在单旋律音高识别上又进一步，开发了比全监督式模型CREPE表现更好的自监督式模型SPICE。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://arxiv.org/pdf/1910.11664.pdf"
+              target="_blank"
+              rel="noopener"
+              >https://arxiv.org/pdf/1910.11664.pdf</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞
+          不管是单音还是复音，总归是有音高的，但是如何对打击乐这种类型的乐器进行自动扒谱呢？师哥Keunwoo
+          Choi的这篇文章用非监督学习的方式给出一个答案。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://github.com/keunwoochoi/DrummerNet"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/keunwoochoi/DrummerNet</a
+            ></span
+          >
+        </p>
+        <p>
+          <strong
+            ><strong>♬&nbsp;</strong>节拍追踪&nbsp;<strong
+              >♬&nbsp;</strong
+            ></strong
+          >
+        </p>
+        <p>
+          维也纳OFAI的Sebastian
+          Böck可以说是研究这个问题的资深专家了，他最新的工作是用多任务学习的方式，同时提升tempo
+          estimation和beat tracking。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="http://archives.ismir.net/ismir2019/paper/000058.pdf"
+              target="_blank"
+              rel="noopener"
+              >http://archives.ismir.net/ismir2019/paper/000058.pdf</a
+            ></span
+          >
+        </p>
+        <p>
+          <span
+            >➥ 训练好的模型开源在<a
+              href="https://github.com/CPJKU/madmom"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/CPJKU/madmom</a
+            ></span
+          >
+        </p>
+        <p>
+          <strong
+            ><strong>♬&nbsp;</strong>和弦识别&nbsp;<strong
+              >♬&nbsp;</strong
+            ></strong
+          >
+        </p>
+        <p>
+          ☞ 为了深度学习出输入数据中的时序信息，注意力模型(attention-based
+          model)是最近比RNN和LSTM更流行的方法，台湾中央研究院的Tsung-Ping
+          Chen和Li Su将其应用在和弦识别上，并获得了19年ISMIR的最佳论文之一。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://github.com/Tsung-Ping/Harmony-Transformer"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/Tsung-Ping/Harmony-Transformer</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞ 想详细了解近20年和弦识别的发展，不要错过这篇C4DM的同事们发表的综述。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="http://archives.ismir.net/ismir2019/paper/000004.pdf"
+              target="_blank"
+              rel="noopener"
+              >http://archives.ismir.net/ismir2019/paper/000004.pdf</a
+            ></span
+          >
+        </p>
+        <p>
+          <strong
+            ><strong>♬&nbsp;</strong>翻唱检测&nbsp;<strong
+              >♬&nbsp;</strong
+            ></strong
+          >
+        </p>
+        <p>
+          除了直接训练端到端的模型去解决一个特定任务，也可以从任务A的模型中提取embedding，应用到任务B中。比如从“主旋律识别任务”的模型中提取embedding，能成功地被应用到翻唱检测的任务中，毕竟原歌曲和其翻唱版本之间的主旋律应该还挺相似的。法国的Guillaume
+          Doras和Geoffroy
+          Peeters就用这个方法实现了目前准确度最高的翻唱检测算法。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="http://archives.ismir.net/ismir2019/paper/000010.pdf"
+              target="_blank"
+              rel="noopener"
+              >http://archives.ismir.net/ismir2019/paper/000010.pdf</a
+            ></span
+          >
+        </p>
+        <hr />
+        <h3>『音乐其他方面的数据分析』</h3>
+        <p>
+          以上传统任务的亮眼成就列举，难免让其他领域的人觉得这不过又是CS大行业的一个音乐分支，其实音乐信息检索这一行充满了统计学家和音乐家。
+        </p>
+        <p>
+          ☞
+          比如说近20年来用户或算法创建的歌单，通过统计学的方法能反映出哪些信息和变化趋势？巴塞罗那MTG组的Lorenzo
+          Porcaro和Emilia Gómez就发表了这么一篇文章。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://github.com/MTG/playlists-stat-analysis"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/MTG/playlists-stat-analysis</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞
+          音乐除了基本的音高节奏等元素，更包含了器乐演奏家在表演时的各种“参数”。佐治亚理工的Alexander
+          Lerch等人发表了关于音乐表演分析综述文章。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="http://archives.ismir.net/ismir2019/paper/000002.pdf"
+              target="_blank"
+              rel="noopener"
+              >http://archives.ismir.net/ismir2019/paper/000002.pdf</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞
+          除了音乐本乐，承载它的交互方式在“让用户发现好音乐”的过程中功不可没，Peter
+          Knees、Markus Schedl和Masataka
+          Goto三位大前辈发表的这篇综述里回顾了过去20年的技术历程。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="http://archives.ismir.net/ismir2019/paper/000003.pdf"
+              target="_blank"
+              rel="noopener"
+              >http://archives.ismir.net/ismir2019/paper/000003.pdf</a
+            ></span
+          >
+        </p>
+        <hr />
+        <h3>『声源分离』</h3>
+        <p>
+          19年的声源分离尤其是在“把输入音频里的人声与伴奏分离开”这项任务上，仿佛被开了光…这要部分归功于相关数据集和指导材料从18年开始被各种大公开，这里必须感谢法国INRIA的Antoine
+          Liutkus和Fabian-Robert Stöter两位老师的无私贡献。
+        </p>
+        <p>
+          <span
+            >➥
+            <a href="https://sigsep.github.io/" target="_blank" rel="noopener"
+              >https://sigsep.github.io/</a
+            ></span
+          >
+        </p>
+        <p>☞ Deezer公司开源的spleeter，目前在Github上已经9千多星，亲测好用。</p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://github.com/deezer/spleeter"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/deezer/spleeter</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞ Facebook
+          Research紧随其后开源demucs，相比于以音频的时频谱做输入的spleeter，这个直接从音频波形下手。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://github.com/facebookresearch/demucs"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/facebookresearch/demucs</a
+            ></span
+          >
+        </p>
+        <hr />
+        <h3>『自动标注』</h3>
+        <p>
+          ☞ 18年总结中提到的Jordi Pons，从MTG顺利博士毕业了，他的毕业论文是Deep
+          neural networks for music and audio tagging。
+        </p>
+        <p>
+          <span>➥ PPT：</span
+          ><span
+            ><a
+              href="http://www.jordipons.me/media/ThesisDefense_JordiPons.pdf"
+              target="_blank"
+              rel="noopener"
+              >http://www.jordipons.me/media/ThesisDefense_JordiPons.pdf</a
+            ></span
+          >
+        </p>
+        <p>
+          <span>➥ 论文：</span
+          ><span
+            ><a
+              href="http://jordipons.me/media/PhD"
+              target="_blank"
+              rel="noopener"
+              >http://jordipons.me/media/PhD</a
+            ><span>Thesis</span>JordiPons.pdf</span
+          >
+        </p>
+        <p>
+          ☞
+          针对于更广义的音频事件检测，我的朋友孔秋强在萨利大学博士毕业了，他不仅论文发得多多多，代码写得也特别清晰明了。在毕业论文最终上线之前，可以先在他的个人主页浏览所有相关工作。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://qiuqiangkong.github.io/"
+              target="_blank"
+              rel="noopener"
+              >https://qiuqiangkong.github.io/</a
+            ></span
+          >
+        </p>
+        <hr />
+        <h3>『智能生成』</h3>
+        <p>
+          其实博主对自动作曲算法本身的关注比较少，所以只对demo做得比较漂亮的两个自动伴奏项目印象深刻。
+        </p>
+        <p>
+          ☞ The Bach Doodle，博主崇拜的Cheng-Zhi Anna
+          Huang等人做出的工作，用户输入一段主旋律（下图黑色音符部分），系统可以自动编排巴赫风格的和声伴奏（下图其他颜色的音符），这项工作也发表在19年ISMIR上。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="http://archives.ismir.net/ismir2019/paper/000097.pdf"
+              target="_blank"
+              rel="noopener"
+              >http://archives.ismir.net/ismir2019/paper/000097.pdf</a
+            ></span
+          >
+        </p>
+        <p>
+          <img
+            data-original-style=""
+            data-index="2"
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJVejLk9ZCRbyTZ98iajzMXfvzcQNOeh7ElK91xDNoFl8rXicpnjFmlVDn7LEntElbVcASeRKSuH8chw/640"
+            _width="677px"
+            alt="Image"
+          />
+        </p>
+        <p>
+          ☞
+          DrumBot，这里自动伴奏的不再是旋律，而是鼓点。背后基于的GrooVAE算法已经发表在19年ICML上，嗯对，又是Magenta开发的。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://arxiv.org/pdf/1905.06118.pdf"
+              target="_blank"
+              rel="noopener"
+              >https://arxiv.org/pdf/1905.06118.pdf</a
+            ></span
+          >
+        </p>
+        <p>
+          <img
+            data-original-style=""
+            data-index="3"
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJVejLk9ZCRbyTZ98iajzMXfvNFe8y94N3VWIdpLUsUhCdwV1XEOe9svHiaf6DhImZ60TX8wRm4my3qw/640"
+            _width="677px"
+            alt="Image"
+          />
+        </p>
+        <p>
+          ☞ 对自动作曲算法本身感兴趣的，可以参考19年ISMIR上楊奕軒老师的Tutorial:
+          Generating Music with GANs
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://salu133445.github.io/ismir2019tutorial/"
+              target="_blank"
+              rel="noopener"
+              >https://salu133445.github.io/ismir2019tutorial/</a
+            ></span
+          >
+        </p>
+        <hr />
+        <h3>『新数据集』</h3>
+        <p>☞ The MTG-Jamendo Dataset for Automatic Music Tagging</p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://mtg.github.io/mtg-jamendo-dataset/"
+              target="_blank"
+              rel="noopener"
+              >https://mtg.github.io/mtg-jamendo-dataset/</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞ Da-TACOS: A Dataset for Cover Song Identification and Understanding
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://mtg.github.io/da-tacos/"
+              target="_blank"
+              rel="noopener"
+              >https://mtg.github.io/da-tacos/</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞ The AcousticBrainz Genre Dataset: Multi-Source, Multi-Level,
+          Multi-Label, and Large-Scale
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://mtg.github.io/acousticbrainz-genre-dataset/"
+              target="_blank"
+              rel="noopener"
+              >https://mtg.github.io/acousticbrainz-genre-dataset/</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞ The Harmonix Set: Beats, Downbeats, and Functional Segment
+          Annotations of Western Popular Music
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://github.com/urinieto/harmonixset"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/urinieto/harmonixset</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞ SUPRA: Digitizing the Stanford University Piano Roll Archive
+          数据集的建立过程发表在19年ISMIR上并荣获最佳论文，恭喜Zhengshan
+          Shi学姐！
+        </p>
+        <p>
+          <span
+            >➥
+            <a href="https://supra.stanford.edu/" target="_blank" rel="noopener"
+              >https://supra.stanford.edu/</a
+            ></span
+          >
+        </p>
+        <p>
+          ☞
+          古琴数据集，北邮学生吴雨松主导建立，相关技术已发表在19年全国声音与音乐技术会议上。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://github.com/lukewys/Guqin-Dataset"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/lukewys/Guqin-Dataset</a
+            ></span
+          >
+        </p>
+        <hr />
+        <h3>『关于2019的一点题外话』</h3>
+        <p>
+          19年是ISMIR国际会议的20周年，除了上面提到的论文，还有许许多多有趣的工作，下方链接里汇总了大部分海报。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://github.com/keunwoochoi/ismir-2019-posters"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/keunwoochoi/ismir-2019-posters</a
+            ></span
+          >
+        </p>
+        <p>
+          对博主来说，19年也是个丰收的喜悦年，起码叫我一声Dr.
+          Liang我也敢答应了！周围的朋友们也都陆续提交了博士毕业论文，虽然我们大部分没有继续留在学术界，但完全不会停止对音乐科技项目的密切关注和开源支持。最后祝大家2020年一切顺利，抱拳！
+        </p>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/music-tech-2020.html
+++ b/articles/music-tech-2020.html
@@ -1,0 +1,813 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>「INFO」2020年度那些亮眼的音乐科技成就 - 无痛入门音乐科技</title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「INFO」2020年度那些亮眼的音乐科技成就</h1>
+      <div class="meta">2021年3月6日 09:11 · 无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            工作节奏太快了，已是2021年阳春三月才抽出些时间，简单盘点一下2020年音乐科技方面令博主印象深刻的学术研究和工业落地。个人眼界有限，如有勘误或遗漏，还请包涵！
+          </p>
+        </blockquote>
+        <section>
+          <span
+            >过去的一年是博主成为“互联网打工人”、见证各种音乐信息检索算法从学术的理想状态中剥离出来、并真实落地到业务场景里的一年，所以主要关注音乐科技的实际应用、多模态数据共同做深度学习、以及Representation
+            Learning这几个方面。因此本文将在以下几点做简要总结：</span
+          >
+        </section>
+        <ul>
+          <li>
+            <section>
+              <span>传统任务在业界：节奏识别/歌曲分段/自动扒谱/翻唱检测</span>
+            </section>
+          </li>
+          <li>
+            <section>
+              <span>多模态带来新花样：从文本与图像中获得启发</span>
+            </section>
+          </li>
+          <li>
+            <section><span>Representation Learning</span></section>
+          </li>
+          <li>
+            <section><span>更多造福大众的教程/数据集/开源工具</span></section>
+          </li>
+        </ul>
+        <section>
+          <span
+            >P.S. 内容较多且有链接，建议在电脑网页端浏览。往期回顾可查看</span
+          ><a
+            target="_blank"
+            href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483768&amp;idx=1&amp;sn=5be59ee8a281e9920399820f09a339ec&amp;chksm=fe0d9fd7c97a16c1aa4e687160944991218d1875d523b272c54143c59e360c4fc10e43700879&amp;scene=21#wechat_redirect"
+            textvalue="2018年的音乐科技年度总结"
+            data-itemshowtype="0"
+            tab="innerlink"
+            data-linktype="2"
+            hasload="1"
+            ><span>2018年度总结</span></a
+          ><span>&nbsp;&amp; </span
+          ><span
+            ><a
+              target="_blank"
+              href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483802&amp;idx=1&amp;sn=9790d92e685baa74f28f3053c4ff15ef&amp;chksm=fe0d9f35c97a1623fc305ce8c79b19e7451f5500d95b08c4fd5c27e47c8a256094c3e2022066&amp;scene=21#wechat_redirect"
+              textvalue="2019年度总结"
+              data-itemshowtype="0"
+              tab="innerlink"
+              data-linktype="2"
+              hasload="1"
+              >2019年度总结</a
+            >。<a
+              target="_blank"
+              href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483802&amp;idx=1&amp;sn=9790d92e685baa74f28f3053c4ff15ef&amp;chksm=fe0d9f35c97a1623fc305ce8c79b19e7451f5500d95b08c4fd5c27e47c8a256094c3e2022066&amp;scene=21#wechat_redirect"
+              textvalue="2019年度总结"
+              data-itemshowtype="0"
+              tab="innerlink"
+              data-linktype="2"
+              hasload="1"
+            ></a
+          ></span>
+        </section>
+        <section>
+          <span
+            >P.P.S.
+            本文出现的所有产品都是为了举例说明，都是个人观点，没有打广告。</span
+          >
+        </section>
+        <hr />
+        <h3>『传统任务在业界』</h3>
+        <p>
+          <span
+            ><strong
+              ><strong>♬ 节奏识别</strong>&nbsp;<strong>♬&nbsp;</strong></strong
+            ></span
+          >
+        </p>
+        <p>
+          <span
+            >☞ 首先还是要respect一下Sebastian
+            Böck，这些年深耕关于节奏节拍的一切，在20年ISMIR会议上发表论文Deconstruct,
+            Analyse, Reconstruct: How to Improve Tempo, Beat, and Downbeat
+            Estimation。把state-of-the-art的模型都给扒出来看，在统一的数据集上挨个评估，当然也实至名归获得Best
+            Evaluation Award。</span
+          >
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://program.ismir2020.net/poster_4-14.html"
+              target="_blank"
+              rel="noopener"
+              >https://program.ismir2020.net/poster_4-14.html</a
+            ></span
+          >
+        </p>
+        <p>
+          <span
+            >☞
+            那么在业界，这些节拍信息能辅助曲库区分快歌慢歌，但更直观的一个应用是Q音探歌的“卡点DJ电台”、QQ音乐的“4D震动”等效果的展现，根据beat或downbeat的时间点、或者不同鼓出现的时刻，来调动手机中闪光或马达的开闭（此处shoutout
+            to 曹翔大前辈）。</span
+          >
+        </p>
+        <p>
+          <span
+            >☞ 说到这里就要提一下automatic drum
+            transcription的研究了，以往的成果主要还是在非常有限的鼓种类中进行识别，对于更复杂的情况，Yu
+            Wang等人训练Prototypical Network实现Few-shot Drum Transcription in
+            Polyphonic
+            Music。这种few-shot的思路，可应用到Adobe产品中，对音频实现“Ctrl+F”的功能，即给定一个音频小片段，将某个大段音频内出现该小片段的时间点通通找到。</span
+          >
+        </p>
+        <p>
+          <span
+            >➥&nbsp;<a
+              href="https://program.ismir2020.net/poster_1-14.html"
+              target="_blank"
+              rel="noopener"
+              >https://program.ismir2020.net/poster_1-14.html</a
+            ></span
+          >
+        </p>
+        <p>
+          <strong
+            ><strong>♬ 歌曲分段</strong>&nbsp;<strong>♬&nbsp;</strong></strong
+          >
+        </p>
+        <p>
+          <span
+            ><span>☞&nbsp;</span>人见人爱的Oriol
+            Nieto博士毕业三年后，在Pandora工作之余也再次回溯了他的毕业论文，并联合其他人发表了一篇非常棒的综述：如何基于音频做歌曲分段。</span
+          >
+        </p>
+        <section>
+          <span
+            >Nieto, O., Mysore, G.J., Wang, C.-. i ., Smith, J.B.L., Schlüter,
+            J., Grill, T. and McFee, B., 2020. Audio-Based Music Structure
+            Analysis: Current Trends, Open Challenges, and Applications.
+            Transactions of the International Society for Music Information
+            Retrieval, 3(1), pp.246–263.&nbsp;</span
+          >
+        </section>
+        <section>
+          <span
+            >➥
+            <a
+              href="http://doi.org/10.5334/tismir.54"
+              target="_blank"
+              rel="noopener"
+              >http://doi.org/10.5334/tismir.54</a
+            ></span
+          >
+        </section>
+        <p>
+          <span
+            ><span>☞&nbsp;</span
+            >分段结果对于业界来讲，可以将“副歌”对应的片段挑出来，比如一些歌曲的副歌起始时刻在QQ音乐播放进度条中就用一个“小白点”来告知用户，再比如为了方便用户分享年终盘点的15秒视频到朋友圈，视频里的背景音乐就选取了歌曲的某个片段。</span
+          >
+        </p>
+        <p>
+          <strong
+            ><strong>♬ 自动扒谱</strong>&nbsp;<strong>♬&nbsp;</strong></strong
+          >
+        </p>
+        <p>
+          <span
+            >☞
+            这里的主要突破还是在“钢琴音频自动转谱”任务上，字节跳动的孔秋强等人不仅将钢琴按键的时间精确到1毫秒这个量级，还包含了对钢琴按键力度、钢琴踏板等等维度的检测，整体上更加精确（博主本人也感谢下各位对我以前踏板论文的引用哈）。更令人敬佩的是，相关论文、数据集、源代码都是开源，博主本身也在互联网公司，所以非常清楚这件事情有多不容易，salute！</span
+          >
+        </p>
+        <section>
+          <span
+            ><span>➥&nbsp;</span>Qiuqiang Kong, Bochen Li, Jitong Chen, and
+            Yuxuan Wang. "GiantMIDI-Piano: A large-scale MIDI dataset for
+            classical piano music." arXiv preprint arXiv:2010.07061 (2020).
+            <a
+              href="https://arxiv.org/pdf/2010.07061"
+              target="_blank"
+              rel="noopener"
+              >https://arxiv.org/pdf/2010.07061</a
+            ></span
+          >
+        </section>
+        <section>
+          <span
+            ><span>➥&nbsp;</span>Qiuqiang Kong, Bochen Li, Xuchen Song, Yuan
+            Wan, and Yuxuan Wang. "High-resolution Piano Transcription with
+            Pedals by Regressing Onsets and Offsets Times." arXiv preprint
+            arXiv:2010.01815 (2020).
+            <a
+              href="https://arxiv.org/pdf/2010.01815"
+              target="_blank"
+              rel="noopener"
+              >https://arxiv.org/pdf/2010.01815</a
+            ></span
+          >
+        </section>
+        <section>
+          <span
+            >➥
+            <a
+              href="https://github.com/bytedance/GiantMIDI-Piano"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/bytedance/GiantMIDI-Piano</a
+            ></span
+          >
+        </section>
+        <p>
+          <span
+            >☞
+            也许大多数研究都没被落地到某个赚钱的业务中，但这完全不代表“这个研究没有用”，人们会被自己的学识局限在一个井里，评价其他项目难免坐井观天。说个题外话吧，1970年赞比亚修女Mary
+            Jucunda给NASA的科学家Dr. Ernst
+            Stuhlinger写过一封信，问他目前地球上还有这么多小孩子吃不上饭，他怎么能舍得为远在火星的项目花费数十亿美元，他的回信可以见链接。</span
+          >
+        </p>
+        <p>
+          <span
+            ><span>➥&nbsp;</span
+            ><a
+              href="https://lettersofnote.com/2012/08/06/why-explore-space/"
+              target="_blank"
+              rel="noopener"
+              >https://lettersofnote.com/2012/08/06/why-explore-space/</a
+            ></span
+          >
+        </p>
+        <p>
+          <strong
+            ><strong>♬ 翻唱检测</strong>&nbsp;<strong>♬&nbsp;</strong></strong
+          >
+        </p>
+        <p>
+          <span
+            ><span>☞&nbsp;</span>同样是字节跳动的朋友，在MIREX2020的Cover Song
+            Identification任务中取得最佳成绩。相关算法ByteCover不仅在特征学习上去“抵挡”不同版本的歌曲在节奏、调式、音色等方面的转变，而且同时去优化classification
+            loss and triplet loss。</span
+          >
+        </p>
+        <section>
+          <span
+            ><span>➥&nbsp;</span>Xingjian Du, Zhesong Yu, Bilei Zhu, Xiaoou
+            Chen, and Zejun Ma. "ByteCover: Cover Song Identification via
+            Multi-Loss Training." arXiv preprint arXiv:2010.14022
+            (2020).&nbsp;<a
+              href="https://arxiv.org/pdf/2010.14022.pdf"
+              target="_blank"
+              rel="noopener"
+              >https://arxiv.org/pdf/2010.14022.pdf</a
+            ></span
+          >
+        </section>
+        <p>
+          <span
+            ><span>☞&nbsp;</span
+            >翻唱识别也集成到了QQ音乐的听歌识曲功能中，并在音乐知识图谱的建设中发挥作用。</span
+          >
+        </p>
+        <hr />
+        <h3>『多模态带来新花样』</h3>
+        <p>
+          <span
+            ><span>☞&nbsp;</span>在2020年的ISMIR上，第一次举办了Workshop on NLP
+            for Music and
+            Audio，建议大家直接去看论文原稿和录像回放。其中，关于歌词文本的运用给了我和现在的实习生杨泽堉同学很多启发，可以结合文本和音频，来大力提升上文提到的歌曲分段的精确度。再者，已有很多超厉害的开源NLP模型比如BERT和GPT等，也能拿来运用到蒸蒸日上的播客业务中。</span
+          >
+        </p>
+        <section>
+          <span
+            >➥ 论文：<a
+              href="https://www.aclweb.org/anthology/volumes/2020.nlp4musa-1/"
+              target="_blank"
+              rel="noopener"
+              >https://www.aclweb.org/anthology/volumes/2020.nlp4musa-1/</a
+            ></span
+          >
+        </section>
+        <section>
+          <span
+            >➥ 录像：<a
+              href="https://www.youtube.com/channel/UCtWGAGz6I_1aRetS8U4rYcA/featured"
+              target="_blank"
+              rel="noopener"
+              >https://www.youtube.com/channel/UCtWGAGz6I_1aRetS8U4rYcA/featured</a
+            ></span
+          ><span><br /></span>
+        </section>
+        <p>
+          <span
+            >☞
+            对于图像或视频信息与音频的结合运用方面，有两位朋友在2020年都获得了博士学位，推荐阅读他们的毕业论文。</span
+          >
+        </p>
+        <section>
+          <span
+            >➥&nbsp;Olga Slizovskaia. Audio-visual deep learning methods for
+            musical instrument classification and separation. Universitat Pompeu
+            Fabra, 2020.&nbsp;</span
+          >
+        </section>
+        <section>
+          <span
+            ><span>➥&nbsp;</span>Bochen Li. Multi-Modal Analysis for Music
+            Performances. University of Rochester, 2020.</span
+          >
+        </section>
+        <hr />
+        <h3>『Representation Learning』</h3>
+        <p>
+          <span
+            >既然有那么多不同模态的信息，能不能都包进来变成一个难以解释但确实有用的特征矩阵呢？答案是可以。也正是这种“万物皆可Embedding”的思想，让推荐算法一直在迭代，做到更好的个性化推荐。</span
+          >
+        </p>
+        <p>
+          <span
+            >针对于音乐音频信息，Jongpil Lee等人比较了用深度分类方法或metric
+            learning方法得出的不同representation的有效性。</span
+          >
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://program.ismir2020.net/poster_3-15.html"
+              target="_blank"
+              rel="noopener"
+              >https://program.ismir2020.net/poster_3-15.html</a
+            ></span
+          >
+        </p>
+        <p>
+          <span
+            >受到音乐流媒体公司的支持，也开始有更多研究利用用户侧数据得出的Embedding，来助攻音乐信息检索的任务。比如以下三篇：</span
+          >
+        </p>
+        <section>
+          <span
+            >☞&nbsp;Karim M. Ibrahim, Elena V. Epure, Geoffroy Peeters, and Gael
+            Richard. "Should we consider the users in contextual music
+            auto-tagging models?." In ISMIR, 2020.</span
+          >
+        </section>
+        <section>
+          <span
+            >➥&nbsp;<a
+              href="https://program.ismir2020.net/poster_2-17.html"
+              target="_blank"
+              rel="noopener"
+              >https://program.ismir2020.net/poster_2-17.html</a
+            ></span
+          >
+        </section>
+        <section>
+          <span
+            >☞&nbsp;Ayush Patwari, Nicholas Kong, Jun Wang, Ullas Gargi, Michele
+            Covell, and Aren Jansen. "Semantically Meaningful Attributes from
+            Co-listen Embeddings for Playlist Exploration and Expansion." In
+            ISMIR, 2020.</span
+          >
+        </section>
+        <section>
+          <span
+            >➥&nbsp;<a
+              href="https://program.ismir2020.net/poster_4-08.html"
+              target="_blank"
+              rel="noopener"
+              >https://program.ismir2020.net/poster_4-08.html</a
+            ></span
+          >
+        </section>
+        <section>
+          <span
+            >☞&nbsp;Filip Korzeniowski, Oriol Nieto, Matthew McCallum, Minz Won,
+            Sergio Oramas, and Erik Schmidt. "Mood Classification Using
+            Listening Data." In ISMIR, 2020.</span
+          >
+        </section>
+        <section>
+          <span
+            >➥&nbsp;<a
+              href="https://program.ismir2020.net/poster_4-10.html"
+              target="_blank"
+              rel="noopener"
+              >https://program.ismir2020.net/poster_4-10.html</a
+            ></span
+          >
+        </section>
+        <p>
+          <span
+            >我和实习生陈轲同学参与的公司项目，为了解决QQ音乐推荐新歌面临的内容冷启动问题，也利用用户侧的数据，通过metric
+            learning学习音频Embedding。虽然无法开源，但涉及的算法思想中稿了今年的ICASSP，欢迎浏览arxiv来与我们交流。</span
+          >
+        </p>
+        <section>
+          <span
+            >☞ Ke Chen, Beici Liang, Xiaoshuan Ma, and Minwei Gu. "Learning
+            Audio Embeddings with User Listening Data for Content-based Music
+            Recommendation." &nbsp;In ICASSP, 2021.</span
+          >
+        </section>
+        <section>
+          <span
+            >➥&nbsp;<a
+              href="https://arxiv.org/abs/2010.15389"
+              target="_blank"
+              rel="noopener"
+              >https://arxiv.org/abs/2010.15389</a
+            ></span
+          >
+        </section>
+        <hr />
+        <h3>『更多造福大众的资源』</h3>
+        <p>
+          <span>首先安利以下两份tutorial资料，可以说是手把手教学的程度了。</span
+          ><br />
+        </p>
+        <section>
+          <span
+            >☞ "Open-Source Tools &amp; Data for Music Source Separation: A
+            Pragmatic Guide for the MIR Practitioner" By Ethan Manilow, Prem
+            Seetharaman, and Justin Salamon</span
+          >
+        </section>
+        <section>
+          <span
+            >➥&nbsp;<a
+              href="https://github.com/source-separation/tutorial"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/source-separation/tutorial</a
+            ></span
+          >
+        </section>
+        <section>
+          <span
+            >☞&nbsp;"Metric Learning in MIR" By Brian McFee, Jongpil Lee and
+            Juhan Nam</span
+          >
+        </section>
+        <section>
+          <span
+            >➥&nbsp;<a
+              href="https://github.com/bmcfee/ismir2020-metric-learning"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/bmcfee/ismir2020-metric-learning</a
+            ></span
+          >
+        </section>
+        <p>
+          <span
+            >工具类的资源也在2020年完成了不少迭代，比如Essentia集成了Musicnn等TensorFlow模型，使用户更方便的获取这些深度学习模型的embeddings；再比如Librosa发布了v0.8.0；但令我印象更深刻的还是Spotify开源其处理大批量音频任务的框架Klio。</span
+          ><br />
+        </p>
+        <section>
+          <span
+            >➥&nbsp;<a
+              href="https://github.com/spotify/klio"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/spotify/klio</a
+            ></span
+          >
+        </section>
+        <h3></h3>
+        <p><span>数据集相关的新资源有以下：</span></p>
+        <p>
+          <span
+            >☞&nbsp;Eduardo Fonseca, Xavier Favory, Jordi Pons, Frederic Font,
+            Xavier Serra. "FSD50K: an Open Dataset of Human-Labeled Sound
+            Events", arXiv:2010.00475, 2020.</span
+          ><br />
+        </p>
+        <section>
+          <span
+            >➥&nbsp;<a
+              href="https://zenodo.org/record/4060432#.YEMk4JMza_U"
+              target="_blank"
+              rel="noopener"
+              >https://zenodo.org/record/4060432#.YEMk4JMza_U</a
+            ></span
+          >
+        </section>
+        <section>
+          <span>☞&nbsp;The Freesound Loop Dataset and Annotation Tool</span>
+        </section>
+        <section>
+          <span
+            >➥&nbsp;<a
+              href="https://github.com/aframires/freesound-loop-annotator"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/aframires/freesound-loop-annotator</a
+            ></span
+          >
+        </section>
+        <section>
+          <span>☞ Spotify重新开放Million Playlist Dataset</span>
+        </section>
+        <section>
+          <span
+            >➥&nbsp;<a
+              href="https://research.atspotify.com/the-million-playlist-dataset-remastered/"
+              target="_blank"
+              rel="noopener"
+              >https://research.atspotify.com/the-million-playlist-dataset-remastered/</a
+            ></span
+          >
+        </section>
+        <p>
+          <span
+            >另外还有些虽然不算是“资源”但依然能引发我们思考的调查报告，也借此机会分享给各位读者。</span
+          >
+        </p>
+        <p>
+          <span
+            >☞&nbsp;Meijun Liu, Eva Zangerle, Xiao Hu, Alessandro Melchiorre,
+            Markus Schedl. "Pandemics, Music, and Collective Sentiment: Evidence
+            from the Outbreak of COVID-19." In ISMIR, 2020.</span
+          >
+        </p>
+        <p>
+          <span
+            >➥&nbsp;<a
+              href="https://program.ismir2020.net/poster_1-19.html"
+              target="_blank"
+              rel="noopener"
+              >https://program.ismir2020.net/poster_1-19.html</a
+            ></span
+          >
+        </p>
+        <p>
+          <span
+            >☞&nbsp;Avriel C Epps-Darling, Henriette Cramer, Romain Takeo
+            Bouyer. "Female Artist Representation in Music Streaming." In ISMIR,
+            2020.</span
+          >
+        </p>
+        <p>
+          <span
+            >➥&nbsp;<a
+              href="https://program.ismir2020.net/poster_2-11.html"
+              target="_blank"
+              rel="noopener"
+              >https://program.ismir2020.net/poster_2-11.html</a
+            ></span
+          >
+        </p>
+        <p>
+          <span
+            >☞&nbsp;‘Just The Way You Are’: Music Listening and
+            Personality.</span
+          >
+        </p>
+        <p>
+          <span
+            >➥&nbsp;<a
+              href="https://research.atspotify.com/just-the-way-you-are-music-listening-and-personality/"
+              target="_blank"
+              rel="noopener"
+              >https://research.atspotify.com/just-the-way-you-are-music-listening-and-personality/</a
+            ></span
+          >
+        </p>
+        <hr />
+        <h3>『关于2020的一点题外话』</h3>
+        <p>
+          <span
+            >因为疫情的原因，感觉大家2020年过得都有点憋屈，博主也快变成了没有感情的工作机器（从我发文章的频率就能感觉到吧），但能把已有的MIR算法落地、新研发的算法发论文申专利，还是比较有成就感的。而且最近几个月陆续收到了很多学弟学妹发来的offer喜讯，感谢我和这个公众号对他们留学申请时的帮助，我能有实感地知道这个科普没白做，开心。</span
+          >
+        </p>
+        <p>
+          <span
+            >过去的一年还新兴了播客
+            (Podcast)，职业习惯又让我看到许多可以将音乐或泛音频技术落地的点。话说我的partner也成功拿到博士学位，并且他的毕业论文"Computational
+            Methods for Assisting Radio Drama
+            Production"，以及现在的工作也是紧贴播客产业（对我就是想炫耀一下我们是Dual-PhD
+            Couple）。</span
+          >
+        </p>
+        <p>
+          <span
+            ><em
+              >这里可以插个广告：欢迎大家在各大音频平台订阅申申主播的《说得好听》！</em
+            ></span
+          ><span><br /></span>
+        </p>
+        <p>
+          <span
+            >不知道什么时候疫情能过去，许多公司比如Spotify都开始有Work From
+            Anywhere的远程工作制度，这里也借机帮各位海内外朋友看机会，如果有这种接受远程的音频相关工作岗位，请联系我
+            (</span
+          ><span>beici.liang@foxmail.com</span><span>)。</span>
+        </p>
+        <p>
+          <span
+            >同时后天就是国际妇女节了，MIR学界近五六年一直有Women in Music
+            Information Retrieval (WiMIR)
+            项目来帮扶在此行业的女性，鼓励大家关注！同时若有女性朋友在学业或职业上有疑问，也欢迎直接给我来信交流。</span
+          >
+        </p>
+        <p><span>再次感谢大家的订阅，拜个2021的晚年！</span></p>
+        <p>
+          <span><br /></span>
+        </p>
+        <section>
+          <strong><span>往期回顾：</span></strong>
+        </section>
+        <section>
+          <a
+            target="_blank"
+            href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483802&amp;idx=1&amp;sn=9790d92e685baa74f28f3053c4ff15ef&amp;chksm=fe0d9f35c97a1623fc305ce8c79b19e7451f5500d95b08c4fd5c27e47c8a256094c3e2022066&amp;scene=21#wechat_redirect"
+            data-itemshowtype="0"
+            tab="innerlink"
+            data-linktype="2"
+            ><span>「INFO」2019年度那些亮眼的音乐科技成就</span></a
+          ><br />
+        </section>
+        <section>
+          <a
+            target="_blank"
+            href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&amp;mid=2247483768&amp;idx=1&amp;sn=5be59ee8a281e9920399820f09a339ec&amp;chksm=fe0d9fd7c97a16c1aa4e687160944991218d1875d523b272c54143c59e360c4fc10e43700879&amp;scene=21#wechat_redirect"
+            data-itemshowtype="0"
+            tab="innerlink"
+            data-linktype="2"
+            ><span>「INFO」2018年度那些亮眼的音乐科技成就</span></a
+          ><br />
+        </section>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/music-visualization.html
+++ b/articles/music-visualization.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>「MIR-01」要把音乐画出来，总共分几步？ - 无痛入门音乐科技</title>
+  <style>
+    :root {
+      --bg: #f5f5f7;
+      --card-bg: #ffffff;
+      --text: #1d1d1f;
+      --text-secondary: #6e6e73;
+      --accent: #5856d6;
+      --border: #d2d2d7;
+      --code-bg: #f0f0f3;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0d0d12;
+        --card-bg: #1c1c24;
+        --text: #f0f0f5;
+        --text-secondary: #8e8e93;
+        --accent: #7b79ff;
+        --border: #2c2c34;
+        --code-bg: #15151d;
+      }
+    }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", Roboto, "Noto Sans SC", sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.8;
+    }
+    .header {
+      background: linear-gradient(135deg, #0f0c29 0%, #302b63 50%, #24243e 100%);
+      padding: 2rem 1.5rem;
+      text-align: center;
+    }
+    .header a {
+      color: rgba(255,255,255,0.7);
+      text-decoration: none;
+      font-size: 0.9rem;
+    }
+    .header a:hover { color: #fff; }
+    article {
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem 4rem;
+    }
+    article h1 {
+      font-size: 1.8rem;
+      font-weight: 700;
+      margin-bottom: 0.5rem;
+      line-height: 1.3;
+    }
+    .meta {
+      color: var(--text-secondary);
+      font-size: 0.85rem;
+      margin-bottom: 2rem;
+      padding-bottom: 1rem;
+      border-bottom: 1px solid var(--border);
+    }
+    .content { font-size: 1rem; }
+    .content p,
+      .content section { margin-bottom: 1rem; }
+    .content img {
+      max-width: 100%;
+      height: auto;
+      border-radius: 8px;
+      margin: 1rem 0;
+    }
+    .content h2, .content h3 {
+      text-align: center;
+      margin: 1.5rem 0 0.8rem;
+      font-weight: 600;
+    }
+    .content blockquote {
+      border-left: 3px solid var(--accent);
+      padding-left: 1rem;
+      color: var(--text-secondary);
+      margin: 1rem 0;
+    }
+    .content a { color: var(--accent); }
+    .content hr {
+      border: none;
+      border-top: 1px solid var(--border);
+      margin: 1.5rem 0;
+    }
+    .content ul, .content ol {
+      padding-left: 1.5rem;
+      margin-bottom: 1rem;
+    }
+    .content li { margin-bottom: 0.3rem; }
+    .content table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1rem 0;
+    }
+    .content th, .content td {
+      border: 1px solid var(--border);
+      padding: 0.5rem;
+      text-align: left;
+    }
+    .content pre, .content code {
+      font-family: "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+      font-size: 0.85em;
+    }
+    .content code {
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 0.15rem 0.4rem;
+    }
+    .content pre {
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1rem 1.2rem;
+      overflow-x: auto;
+      margin: 1rem 0;
+      line-height: 1.5;
+    }
+    .content pre code {
+      background: none;
+      border: none;
+      padding: 0;
+      font-size: inherit;
+      display: block;
+    }
+    .content pre ol {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+    .content pre li {
+      margin: 0;
+      padding: 0;
+    }
+    .content pre p {
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+  </div>
+  <article>
+    <h1>「MIR-01」要把音乐画出来，总共分几步？</h1>
+    <div class="meta">无痛入门音乐科技</div>
+    <div class="content">
+      <blockquote><p>伦敦最近热得像蒸笼，还没有空调，于是我就想到了冰箱，顺势想到了小品里的大象，想到了大象无形，想到了大音希声。诶等一下，“大音”因为听不到而无法理解，如果能画出来的话，是不是就有可能被get到了呢？</p></blockquote><p><span><strong>♬ 本文为MIR系列，即音乐信息检索(Music Information Retrieval)的第一篇文章 ♬&nbsp;</strong></span></p><p><span><strong><strong>♬&nbsp;</strong>点击最最下方</strong></span><strong><span>阅读原文</span></strong><strong>获取本文GitHub源码<strong>&nbsp;♬</strong></strong></p><p>文章将以描画音乐为中心，解答以下问题：</p><ul><li><p><span>从乐谱中可窥见MIR有哪些基础任务？</span></p></li><li><p><span>MIDI到底是什么格式？又如何能被用作基础任务的“标准答案”？</span></p></li><li><p><span>各种由音频变换成的时频谱到底击中了你心中的哪一谱？</span></p></li></ul><hr><h3>『音乐的表征/Representation』</h3><p>大多数人觉得感受音乐，用耳朵好好去听就可以欣赏了，但对于音乐爱好者来说，必须要用某种形式把自己喜爱的音乐记录、保存、甚至复现或再度创作，心里才舒坦。因此，器乐演奏家手头上少不了五线谱，电音发烧友经常与MIDI打交道，而我与众多数据科学同行们的服务器上更是存着不知道多少WAV或MP3之类的文件。可见音乐被“具现化”后有多种表征形式，以上三个例子分别对应MIR领域内以下三种表征：乐谱（sheet music representation），符号化格式（symbolic representation），与音频文件（audio representation）。</p><p>我们就用下面这个简单的音乐片段为例，看看它在不同的表征形式上是如何被描画的！</p><p></mpvoice></p><hr><h3>『乐谱』</h3><p>这里的乐谱主要指西方的五线谱，上方的音乐片段就是在演奏下方的谱子：</p><p><img src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJU2VH7ia1oPDAoataBFPSKYDw8CSWGD5wnWMMbZBRzrPiafCrBNs7JvibNR2HlvLWrriaDbuGMmZaHSJg/640"></p><p>从五线谱中可知，我们以“四分音符为一拍，每小节有四拍”的基本节奏型，在第一小节的四拍上分别演奏了 <code><span>C4</span></code> <code><span>E4</span></code> <code><span>G4</span></code> <code><span>C5</span></code>，在第二小节的前两拍和后两拍分别演奏了在不同音区的C和弦 <code><span>Cmaj</span></code>，当前的调性是C大调。<br></p><p>乐理基础好的人，听到音乐后都能分析出类似上面一段的内容并记录在五线谱上，这个过程也俗称“扒谱”（transcription）。对于计算机来说，这个过程就是实现MIR内的各类任务，比如：</p><ul><li><p><span>检测新音符出现的时刻（onset detection）</span></p></li><li><p><span>估计新音符的音高（pitch/F0 estimation）</span></p></li><li><p><span>追踪一拍一拍的位置（beat tracking）</span></p></li><li><p><span>和弦的行进（chord progression）</span></p></li><li><p><span>音乐的调性（key detection）</span></p></li></ul><p>以上及其他较主流的MIR任务，在每年的MIREX竞赛上都在试图刷出更高的准确率。当然无论是乐谱还是音乐本身，还蕴含着更多高层次信息，如流派和情绪等等。更神奇的地方在于，即使是同一个谱子，不同演奏家可以做出完全不一样的解读，这种情况下，相比于分析乐谱，分析现场的音频录音更有必要，这其中常涉及到音频特征的提取（audio feature extraction），博主会在之后的文章里详细介绍。</p><p>另外，让计算机理解乐谱内容进而辅助音乐学家的工作，也是一类称为音乐图像识别（optical music recognition）的研究。</p><p>☞ 对“如何自动翻译富含传统民乐智慧的工尺谱”感兴趣的读者，推荐参考北邮李荣峰老师的研究项目。</p><hr><h3>『符号化格式』</h3><p>与其将symbolic representation翻译成符号化格式，不如比喻成“机械眼中的乐谱”。这种格式最早可以追溯到19世纪末的欧洲，也就是自动演奏钢琴（player piano）被发明的时候，这种钢琴用“木手指”代替演奏者的双手，通过缓缓转动纸卷并读取上面被打孔的位置，可驱动“木手指”击琴键奏出音乐。这种纸卷即piano roll就是最原始的符号化格式，许多钢琴家也曾用它记录自己如何弹得一手好琴。</p><p><img src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJU2VH7ia1oPDAoataBFPSKYDibDicQ1ibZib1w0E9Bs4dejQ5FFwGL2nMF5VR1Y6G0RPv2ZACcwr12ErWg/640"></p><p><span>➥ 上图来源于Meinard Müller的《Fundamentals of Music Processing》书中第11页。</span><br></p><p>☞ 对“如何电子化piano roll”感兴趣的读者，推荐参考斯坦福博士生Zhengshan Shi的相关项目。</p><p><span>➥ </span><span><a href="https://ccrma.stanford.edu/~kittyshi/pianoroll/pianoroll.html" target="_blank" rel="noopener">https://ccrma.stanford.edu/~kittyshi/pianoroll/pianoroll.html</a></span></p><p>在现代随着计算机的普及，这种格式就演变成了“计算机眼中的乐谱”，因此包含了MusicXML和MIDI等等。</p><p>单单是五线谱上的一个中央C，在MusicXML文件中就等同于下面这么多行代码：</p><p><img src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJU2VH7ia1oPDAoataBFPSKYDm9h2vRD19t8htM5oal66yZ7UThELN13sub2u3M4JEP4y7HM0pxj6XA/640"></p><p><span>➥ 上图来源<a href="https://en.wikipedia.org/wiki/MusicXML" target="_blank" rel="noopener">https://en.wikipedia.org/wiki/MusicXML</a></span><br></p><p>☞ 如需要对MusicXML文件进行分析，推荐使用 <code><span>music21</span></code>这个第三方python库做助攻。</p><p>在所有符号化格式中，MIDI可以说自80年代来就开始占据了C位。通过以下代码，我们来仔细看看文章最开头的音乐片段在MIDI格式中长什么样子!</p><p>✎ 如果你已经按之前文章配置好编程环境，进入文件夹后先用 <code><span>git</span></code>更新内容，再激活 <code><span>py37</span></code>虚拟环境，之后我们需要另外安装一个 <code><span>pretty_midi</span></code>库（安装此库也能顺便安装上 <code><span>mido</span></code>），再打开 <code><span>jupyter notebook</span></code>运行本文 <code><span>.ipynb</span></code>文件（确保当前kernel为Python[conda env:py37]）：</p><pre><ol><li><p><span><code><span>$ cd intro2musictech</span></code></span></p></li><li><p><span><code><span>$ git pull</span></code></span></p></li><li><p><span><code><span>$ source activate py37</span></code></span></p></li><li><p><span><code><span>(py37)$ pip install pretty_midi</span></code></span></p></li><li><p><span><code><span>(py37)$ jupyter notebook</span></code></span></p></li></ol></pre><p>下方代码可以将示例音乐片段对应的MIDI文件“打印”出来，可见MIDI格式的本质是遵循着一个标准技术规格（MIDI 1.0）将所有音乐中涉及的元素编码成数字数据的结构。该标准也声明了硬件和软件之间传输MIDI的协议，方便MIDI在各种合成器（synthesizer）和数字音乐工作站（DAW）之间被广泛使用。</p><pre><ol><li><p><span><code><span>import</span><span> mido</span></code></span></p></li><li><p><span><code><span>midi_data = mido.</span><span>MidiFile</span><span>(filename=</span><span>'attachment/mir01-midi.mid'</span><span>)</span></code></span></p></li><li><p><span><code><span>for</span><span> i, track </span><span>in</span><span> enumerate(midi_data.tracks):</span></code></span></p></li><li><p><span><code><span> &nbsp; &nbsp;</span><span>print</span><span>(</span><span>'Track {}: {}'</span><span>.format(i, track.name))</span></code></span></p></li><li><p><span><code><span> &nbsp; &nbsp;</span><span>for</span><span> msg </span><span>in</span><span> track:</span></code></span></p></li><li><p><span><code><span> &nbsp; &nbsp; &nbsp; &nbsp;</span><span>print</span><span>(msg)</span></code></span></p></li></ol></pre><p><span>➥ 输出结果：</span></p><p><img src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJU2VH7ia1oPDAoataBFPSKYDSOqj1X9WI74EUicS75Uqu25hmLZdqP7kF8k9j1ulYbZ5mPzZTd2tYwg/640"></p><p>我们也可以用把上面的结果画成piano roll的样子，这也是MIDI在各种DAW中所呈现的模样。<br></p><pre><ol><li><p><span><code><span>import</span><span> pretty_midi</span></code></span></p></li><li><p><span><code><span>import</span><span> librosa, librosa.display</span></code></span></p></li><li><p><span><code><span>import</span><span> matplotlib.pyplot </span><span>as</span><span> plt </span></code></span></p></li><li><p><span><code></code></span></p></li><li><p><span><code><span>def</span><span> plot_piano_roll(midi_data, start_pitch, end_pitch, fs=</span><span>100</span><span>):</span></code></span></p></li><li><p><span><code><span> &nbsp; &nbsp;librosa.display.specshow(midi_data.get_piano_roll(fs)[start_pitch:end_pitch],</span></code></span></p></li><li><p><span><code><span> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;hop_length=</span><span>1</span><span>, sr=fs, x_axis=</span><span>'time'</span><span>, y_axis=</span><span>'cqt_note'</span><span>,</span></code></span></p></li><li><p><span><code><span> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;fmin=pretty_midi.note_number_to_hz(start_pitch))</span></code></span></p></li><li><p><span><code></code></span></p></li><li><p><span><code><span>plt.figure(figsize=(</span><span>8</span><span>,</span><span>6</span><span>))</span></code></span></p></li><li><p><span><code><span>midi_data = pretty_midi.</span><span>PrettyMIDI</span><span>(</span><span>'attachment/mir01-midi.mid'</span><span>)</span></code></span></p></li><li><p><span><code><span>plot_piano_roll(midi_data,</span><span>60</span><span>,</span><span>84</span><span>)</span></code></span></p></li><li><p><span><code><span>plt.title(</span><span>'piano roll plot of a midi file'</span><span>)</span></code></span></p></li></ol></pre><p><span>➥ 输出结果：</span></p><p><img src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJU2VH7ia1oPDAoataBFPSKYDQvd5pdEoVevoAeL3dvB7ud6uhKKkPOHibBqpZpF6Zext9dm1Nm49uibA/640"></p><p>可见，MIDI能准确记录某个音在什么时刻以何种力度被弹下，有些MIDI文件还含有节奏信息即能知道拍子和重音拍子（beat/downbeat）的位置，这些都表明MIDI可以在MIR任务中担任标准答案（ground truth）的角色，这也比人工做标注更加准确。<br></p><p>需要注意的是，MIDI中的时间并不是按我们常见的分秒表示的，而是以 <code><span>tick</span></code>为单位，而一分钟内有多少个 <code><span>tick</span></code>还取决于当前MIDI文件内规定一拍上有多少tick以及一分钟有多少拍。</p><p>☞ 目前piano transcription任务中所用到的数据库，大多包括钢琴音频及其对应的MIDI文件，如MAPS Dataset。</p><hr><h3>『音频文件和它的时频谱们』</h3><p>终于说到了市面上最常见的音乐表征格式——音频！音频文件最常见的两种格式是WAV和MP3，两者区别主要在于音频是否被压缩，MP3因为被压缩了所以音质没有WAV那么“真”但文件占得地方可小得多。</p><p>音频文件中的参数可以衡量它到底能多逼真地表征音乐。首先采样频率（sample rate）反映该音频的频率范围，根据奈奎斯特定律，44100Hz的采样率能表现的频率范围是0-22050Hz，而人耳本身的频率范围是20-20000Hz，所以这种采样率下的音频文件听上去完全没毛病。另外一个参数叫位深（bit）用来反映采得每个样的振幅可以被多精细的表示，16 bit就代表当前采样的振幅是0-65536（2^16）中的某个数值，但是我们在DAW里看到的经常是分贝的值（dB）且0为最大值，一个bit大约等于6dB，那么16 bit就涵盖了-96到0dB的动态范围。</p><p>我们用下行代码加载本文最开始的音频片段，发现它在计算机眼里就是个长260864的一维数组……</p><pre><ol><li><p><span><code><span>audio_data, sr = librosa.load(</span><span>'attachment/mir01-music-example.wav'</span><span>, sr=</span><span>None</span><span>)</span></code></span></p></li><li><p><span><code><span>print</span><span>(</span><span>"音频样本数：{}"</span><span>.format(len(audio_data)))</span></code></span></p></li></ol></pre><p>➥ 输出结果 <code><span>音频样本数：260864</span></code></p><p>MIR的最终目标之一就是让计算机把这个一维数组活活翻译成乐谱或符号化格式。为了实现这个目标，MIR中有着许许多多的子任务，且大多数子任务下的第一步，就是将一维数组变换成时频谱的矩阵，也就能知道每个单位时刻内的频率响应，这个过程也和人耳的听觉机制相吻合。</p><p>那么如何才能知道这些时域上的样本在频域上的表现呢？Baron Jean Baptiste Joseph Fourier也就是傅里叶同志，早就给出了我们解决问题的答案：<strong>任何连续周期信号可以由一组适当的正弦曲线组合而成</strong>。这位能跟着拿破仑远征埃及的数学家外加物理学家，实在是太硬核了……我简单用音乐例子翻译下这句话就是一个仅含有C和弦的音频信号可以由CEG三个音的正弦曲线组合而成。若想知道每个成分具体占了多少比重，就需要做傅里叶变换得到频谱，看看振幅了！</p><p>对于计算机来说，面对的是自然界连续信号采样后的离散信号，所以做的是离散傅里叶变换（DFT）或者“加速版”即快速傅里叶变换（FFT），这两者只会返回一个频率响应的“综述”，如果想知道频率响应随时间的变化，就需要沿着时间轴做个“滑动版”DFT或FFT，也就是短时傅里叶变换（STFT）。下面的代码可以画出本文音乐片段在时域上的波形图和STFT后的频谱图（功率谱）。</p><pre><ol><li><p><span><code><span>import</span><span> numpy </span><span>as</span><span> np</span></code></span></p></li><li><p><span><code><span># 加载音频</span></code></span></p></li><li><p><span><code><span>audio_data, sr = librosa.load(</span><span>'attachment/mir01-music-example.wav'</span><span>, sr=</span><span>None</span><span>)</span></code></span></p></li><li><p><span><code><span># 对音频数据做STFT，使用窗长为n_fft即2048/44100=46ms</span></code></span></p></li><li><p><span><code><span># 对该窗下的音频数据做FFT则返回1+n_fft/2个频点上的内容</span></code></span></p></li><li><p><span><code><span># 将当前窗往下移动hop_length即512/44100=11.6ms再做FFT</span></code></span></p></li><li><p><span><code><span># 重复操作以上内容实现滑动板FFT</span></code></span></p></li><li><p><span><code><span>D = librosa.stft(audio_data, n_fft=</span><span>2048</span><span>, hop_length=</span><span>512</span><span>)</span></code></span></p></li><li><p><span><code><span># 得到的频谱包含振幅和相位两块信息</span></code></span></p></li><li><p><span><code><span># 后续内容将更依赖振幅信息</span></code></span></p></li><li><p><span><code><span>magnitude, phase = librosa.magphase(D)</span></code></span></p></li><li><p><span><code></code></span></p></li><li><p><span><code><span>plt.figure(figsize=(</span><span>15</span><span>,</span><span>10</span><span>))</span></code></span></p></li><li><p><span><code><span># 画出音频数据在时域上的波形图</span></code></span></p></li><li><p><span><code><span>ax1 = plt.subplot(</span><span>2</span><span>,</span><span>1</span><span>,</span><span>1</span><span>)</span></code></span></p></li><li><p><span><code><span>librosa.display.waveplot(audio_data, sr, alpha=</span><span>0.8</span><span>)</span></code></span></p></li><li><p><span><code><span>plt.title(</span><span>'audio data'</span><span>)</span></code></span></p></li><li><p><span><code><span># 画出STFT后的功率谱（以dB为单位）</span></code></span></p></li><li><p><span><code><span>ax2 = plt.subplot(</span><span>2</span><span>,</span><span>1</span><span>,</span><span>2</span><span>, sharex=ax1)</span></code></span></p></li><li><p><span><code><span>librosa.display.specshow(librosa.amplitude_to_db(magnitude, </span><span>ref</span><span>=np.max), sr=sr, y_axis=</span><span>'linear'</span><span>, x_axis=</span><span>'time'</span><span>)</span></code></span></p></li><li><p><span><code><span>plt.title(</span><span>'STFT spectrogram'</span><span>)</span></code></span></p></li></ol></pre><p><span>➥ 输出结果：</span></p><p><img src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJU2VH7ia1oPDAoataBFPSKYDFaL5NcpvRF4icGUxGUzBh6Ee0pib2wotdDwWhq7CM1fgcDmia6LOAIIuA/640"></p><p>STFT频谱的纵轴上是频点（frequency bin）等间隔分布，频率分辨率为sr/n_fft。然而人类的听觉认知对频率并不是这样线性等间隔理解的，比如你听了1000Hz的声音之后，再去听2000Hz的声音，并不会觉得频率是二倍的关系，反而觉得频率只增加了一点儿，梅尔标度就是反应了人耳到底感受频率增加的一把尺，把这把尺的标度用在频谱上即为梅尔频谱。<br></p><p>在处理和音乐相关的频谱时，我们也许更希望频率轴对应的是各个音符的音高，因此常数Q变换（CQT）得到的频谱也十分常见。</p><p>我们用下面的代码对比看下同一段音乐的不同频谱图：</p><pre><ol><li><p><span><code><span>plt.figure(figsize=(</span><span>15</span><span>,</span><span>15</span><span>))</span></code></span></p></li><li><p><span><code><span># STFT</span></code></span></p></li><li><p><span><code><span>ax1 = plt.subplot(</span><span>3</span><span>,</span><span>1</span><span>,</span><span>1</span><span>)</span></code></span></p></li><li><p><span><code><span>D = librosa.stft(audio_data, n_fft=</span><span>2048</span><span>, hop_length=</span><span>512</span><span>)</span></code></span></p></li><li><p><span><code><span>magnitude, phase = librosa.magphase(D)</span></code></span></p></li><li><p><span><code><span>librosa.display.specshow(librosa.amplitude_to_db(magnitude, </span><span>ref</span><span>=np.max), sr=sr, y_axis=</span><span>'linear'</span><span>, x_axis=</span><span>'time'</span><span>)</span></code></span></p></li><li><p><span><code><span>plt.title(</span><span>'STFT spectrogram'</span><span>)</span></code></span></p></li><li><p><span><code><span># Mel</span></code></span></p></li><li><p><span><code><span>ax2 = plt.subplot(</span><span>3</span><span>,</span><span>1</span><span>,</span><span>2</span><span>, sharex=ax1)</span></code></span></p></li><li><p><span><code><span>S = librosa.feature.melspectrogram(S=D)</span></code></span></p></li><li><p><span><code><span>magnitude, phase = librosa.magphase(S)</span></code></span></p></li><li><p><span><code><span>librosa.display.specshow(librosa.amplitude_to_db(magnitude, </span><span>ref</span><span>=np.max), sr=sr, y_axis=</span><span>'mel'</span><span>, x_axis=</span><span>'time'</span><span>)</span></code></span></p></li><li><p><span><code><span>plt.title(</span><span>'Mel spectrogram'</span><span>)</span></code></span></p></li><li><p><span><code><span># CQT</span></code></span></p></li><li><p><span><code><span>ax3 = plt.subplot(</span><span>3</span><span>,</span><span>1</span><span>,</span><span>3</span><span>, sharex=ax1)</span></code></span></p></li><li><p><span><code><span>C = librosa.cqt(audio_data, sr=sr, hop_length=</span><span>512</span><span>)</span></code></span></p></li><li><p><span><code><span>magnitude, phase = librosa.magphase(C)</span></code></span></p></li><li><p><span><code><span>librosa.display.specshow(librosa.amplitude_to_db(magnitude, </span><span>ref</span><span>=np.max), sr=sr, y_axis=</span><span>'cqt_note'</span><span>, x_axis=</span><span>'time'</span><span>)</span></code></span></p></li><li><p><span><code><span>plt.title(</span><span>'CQT spectrogram'</span><span>)</span></code></span></p></li></ol></pre><p><span>➥ 输出结果：</span></p><p><img src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJU2VH7ia1oPDAoataBFPSKYDlGx0SNiaicqXwc93BOcJj4oaaQwibUUnHTGaSEl8iczL8GuibqyaU4hRlfA/640"></p><p>此外，色谱图（chromagram）在和弦识别的任务中比以上几种频谱图更为有效，关于它的具体内容在今后讲解和弦识别时再做介绍。<br></p><hr><p>以上就是博主能想到“画出音乐”的各种格式了！</p><p>今后MIR系列的文章会以时频谱为主，看看各路音频特征到底是怎么从这里诞生的≖‿≖</p><p><span><strong>♬ 点击下方</strong></span><span><strong>阅读原文</strong></span><span><strong>获取本文Github源码 ♬</strong></span></p>
+    </div>
+  </article>
+</body>
+</html>

--- a/articles/piano-complexity.html
+++ b/articles/piano-complexity.html
@@ -1,0 +1,265 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>「NIME-03」为什么说钢琴是乐器之王？复杂！ - 无痛入门音乐科技</title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「NIME-03」为什么说钢琴是乐器之王？复杂！</h1>
+      <div class="meta">2018年8月28日 00:24 · 无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            由知乎上的问题“有哪些钢琴上的事实，没有一定钢琴知识的人不会相信”想到的一篇声学相关小介绍。
+          </p>
+        </blockquote>
+        <p>
+          <span
+            ><strong
+              >♬
+              本文为NIME系列第3篇文章，乐器不新奇，但这些钢琴声学的知识也许有点儿新奇
+              ♬</strong
+            ></span
+          >
+        </p>
+        <hr />
+        <p>
+          钢琴由于其丰富的表现力经常被大众称为“乐器之王”，这其实可以归功于它复杂的物理结构，但高复杂度也使钢琴中许多细微的声学变化不能被全面地建模，因此诸多电钢琴无法复现真钢琴的表现力。
+        </p>
+        <p>首先来看一个“钢琴解剖图”，图里标注的一些术语会在下文提到：</p>
+        <p>
+          <img
+            data-original-style=""
+            data-index="2"
+            src="https://mmbiz.qpic.cn/mmbiz_jpg/7CrMia15fFJWdz45zOlib4qn2tpa7iacQzKTszhW1juRPR55x71lt1WXNxseCXt3QJibctRt6qCvmaW43XNspwlbOg/640"
+            _width="677px"
+            alt="Image"
+            data-report-img-idx="0"
+          />
+        </p>
+        <p>
+          大众所理解的“弹钢琴”这个动作，主要指的是“弹下键盘上(keyboard)的黑白琴键(key)”，实际上整个运作是一种“琴键被按下，带动打击槌(hammer)敲击琴弦(string)”的击弦机制。再加上由Sébastien
+          Erard发明的双重擒纵机制，使得演奏者可以快速地重复弹奏一个音符，而不需要完全放开琴键。当演奏者真正将手指离开琴键时，止音器(damper)就会落在琴弦上使琴弦停止振动。下方视频演示了连奏音符时，打击槌、琴弦、以及止音器之间的交互过程：<span
+            data-ratio="1.7777777777777777"
+            id="js_tx_video_container_0.9122779751166246"
+          ></span
+          ><br />
+        </p>
+        <p>
+          我们可以从视频中看到，当弹下“一个”琴键时，对应敲击了“三个”琴弦，这不仅仅是为了增加音量，更是使每个音听上去更饱满。而且从低音区(bass)到高音区(treble)，琴弦的长短粗细也不一样，越长的琴弦振动频率(frequency)越低，所以发出的音高(pitch)也就越低。琴弦主要由琴桥(bridge)支撑一端，低中音区琴弦的另一端由定弦器(pin)支撑，高音区的另一端则由承轴部件支撑。此外，琴弦与琴弦、琴弦与琴板(soundboard)等等部件之间发生的共振，都可以让每个音听上去不那么单调。而踏板(pedal)的使用则会进一步改变每个音的音色，比如最右侧的延音踏板就能抬起所有琴弦上的止音器，因此让当前正在发声的音符持续发声，同时让已经“被静止”的琴弦轻微地参与共振，共同营造一种“梦幻”的氛围。
+        </p>
+        <p>
+          以上可知，一个钢琴上每个琴键具体会发出什么音色的声音，首先要取决于该钢琴是否符合制造标准，包括琴板材料、琴框形状、键盘高度、琴键摁下的深度、打击槌的型号、琴弦的直径和张力等等等等不要太多；然后需要调琴师傅对每个琴键进行调校，对每根琴弦进行调音（确保其发出对应音阶正确音高的程序），以及对每个打击槌进行整音（调整槌的硬度和弹性从而消除杂音、强调主音、并平衡音色）；最后在演奏家弹奏过程中，不同的力度会发出强(forte)、中(mezzo)、弱(piano)三种声音。
+        </p>
+        <p>
+          Pianoteq作为一款成熟的基于物理建模的商用声源软件，就将以上因素纳入到其声音合成过程的诸多可控参数中，软件端截图如下，不同牌子/型号的钢琴的初始值会有所不同：
+        </p>
+        <p>
+          <img
+            data-original-style=""
+            data-index="3"
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJWdz45zOlib4qn2tpa7iacQzKCR9BoKJ3H1hDaWyvesYhPjw6jdDkJmicGKeUbdEn1OSZ9ibL64kibRPIw/640"
+            _width="677px"
+            alt="Image"
+          />
+        </p>
+        <p>
+          最后，听众在听到一首钢琴曲时，还会由于曲子在录制时所处的场地、录音器材的设置等，听出“明明是同一个钢琴弹出来的曲子，怎么听上去不一样”的效果！当然大部分录音设置会根据所录钢琴曲的风格进行调整，举两个麦克风摆位的例子：<br />
+        </p>
+        <p>✎ 用两个麦克近距离录制古典钢琴曲时的摆位</p>
+        <p>
+          <img
+            data-original-style=""
+            data-index="4"
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJWdz45zOlib4qn2tpa7iacQzKOTehvzlfmxmXbAwlSd1SLJursaqpyqyh41ehTic4UVveibNVb1HCF03Q/640"
+            _width="677px"
+            alt="Image"
+          />
+        </p>
+        <p>✎ 用四个麦克录制蓝调钢琴曲时的摆位</p>
+        <p>
+          <img
+            data-original-style=""
+            data-index="5"
+            src="https://mmbiz.qpic.cn/mmbiz_png/7CrMia15fFJWdz45zOlib4qn2tpa7iacQzK5tt5jOp9QHHZ6EuFxbuibB5U9DW4NzHj4MOjNLnwwyF4nAwhZW0obEA/640"
+            _width="677px"
+            alt="Image"
+          />
+        </p>
+        <p>
+          录音之后还会进行混音(mixing)和母带(mastering)等等，才最终呈现出多数听众听歌时感受到的钢琴声，而这其中的奥秘又是另外一门声音工程的学问了！
+        </p>
+        <hr />
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/podcast-ep7.html
+++ b/articles/podcast-ep7.html
@@ -1,0 +1,318 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>「说得好听」EP7-音乐推荐算法的小秘密 - 无痛入门音乐科技</title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「说得好听」EP7-音乐推荐算法的小秘密</h1>
+      <div class="meta">2020年5月16日 08:34 · 无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            说得好听是一档关于音乐及泛音乐文化的谈话类播客节目。我们试图通过不同角度和背景去探讨当下音乐领域所发生的大事小情。
+          </p>
+        </blockquote>
+        <section>
+          <span>上周末母亲节的</span
+          ><span
+            >时候, 博主有幸作为"说得好听"的第七期嘉宾,
+            和申申主播愉快地聊了一个多小时音乐算法和音乐推荐的事情,
+            这里贴上"官方导览词":&nbsp;</span
+          ><br />
+        </section>
+        <section>
+          <span
+            >喜新厌旧大概是人类DNA中的木桶效应。无论你有多长情，总会有吃腻的菜，穿烦了的衣服，以及，听腻的歌。</span
+          >
+        </section>
+        <section>
+          <span
+            >据研究，和新陈代谢一样，从30岁开始，人开始慢慢难以接受新歌，并且对于音乐种类的探索也逐渐变得缓慢。</span
+          >
+        </section>
+        <section>
+          <span
+            >如何能解决我们对新音乐的需求，并且能在自己的舒适区尽可能地听到好歌，音乐推荐算法的出现似乎可以完美解决这个问题。</span
+          >
+        </section>
+        <section>
+          <span
+            >音乐推荐算法究竟是怎么成为“最懂你品味的那个人”的？想要申请音乐算法相关学位需要了解什么？音乐算法为什么还不能代替人工？如果你的算法推荐的不准该怎么“训练”它？</span
+          >
+        </section>
+        <section>
+          <span
+            >荣获知乎“无乐器演奏”全网第一，学术界的网红梁博士这一期就带大家走近科学。</span
+          >
+        </section>
+        <section>
+          <mp-common-qqmusic
+            mid="0023zQPx1b3O06"
+            albumurl="https://y.gtimg.cn/music/photo_new/T002R500x500M000002Hh4qm4NkuYA.jpg"
+            audiourl="http://isure.stream.qqmusic.qq.com/C2000023zQPx1b3O06.m4a?guid=2000001731&amp;vkey=9026F44C2B8AC5E796E15E4B73590B94D88ECDFC9E749BBF90187982D3DE2BD5A2969CD3F4E1484131E5792078D4256757B1B41BDE988781&amp;uin=&amp;fromtag=50"
+            music_name="说得好听EP7-音乐推荐算法的小秘密"
+            singer="说的好听&nbsp;-&nbsp;说得好听"
+            play_length="4320"
+            src="/cgi-bin/readtemplate?t=tmpl/qqmusic_tmpl&amp;singer=%E8%AF%B4%E7%9A%84%E5%A5%BD%E5%90%AC%20-%20%E8%AF%B4%E5%BE%97%E5%A5%BD%E5%90%AC&amp;music_name=%E8%AF%B4%E5%BE%97%E5%A5%BD%E5%90%ACEP7-%E9%9F%B3%E4%B9%90%E6%8E%A8%E8%8D%90%E7%AE%97%E6%B3%95%E7%9A%84%E5%B0%8F%E7%A7%98%E5%AF%86&amp;albumurl=https%3A%2F%2Fy.gtimg.cn%2Fmusic%2Fphoto_new%2FT002R68x68M000002Hh4qm4NkuYA.jpg&amp;musictype=1"
+            musictype="1"
+            otherid="0023zQPx1b3O06"
+            albumid="002Hh4qm4NkuYA"
+            jumpurlkey=""
+            data-pluginname="insertaudio"
+            posindex="0"
+            musicid="264878465"
+          ></mp-common-qqmusic>
+        </section>
+        <hr />
+        <h3>『关于说得好听』</h3>
+        <p><span>本期节目在各大音频平台上的链接:</span></p>
+        <p>
+          <span
+            ><span><span>☞</span>&nbsp;</span><span>喜马拉雅：</span></span
+          >
+        </p>
+        <p>
+          <span
+            ><span
+              ><a
+                href="https://www.ximalaya.com/yule/32100074/296811872"
+                target="_blank"
+                rel="noopener"
+                >https://www.ximalaya.com/yule/32100074/296811872</a
+              ></span
+            ></span
+          >
+        </p>
+        <p>
+          <span><span>☞&nbsp;</span> 网易云音乐：</span>
+        </p>
+        <p>
+          <span
+            ><a
+              href="https://music.163.com/#/program?id=2067161039"
+              target="_blank"
+              rel="noopener"
+              >https://music.163.com/#/program?id=2067161039</a
+            ></span
+          >
+        </p>
+        <p>
+          <span><span>☞&nbsp;</span> QQ音乐：</span>
+        </p>
+        <p>
+          <span
+            ><a
+              href="https://y.qq.com/n/yqq/song/0023zQPx1b3O06.html"
+              target="_blank"
+              rel="noopener"
+              >https://y.qq.com/n/yqq/song/0023zQPx1b3O06.html</a
+            ></span
+          >
+        </p>
+        <section>
+          <span><span>☞&nbsp;</span> 苹果播客：</span>
+        </section>
+        <section>
+          <span
+            ><a
+              href="https://podcasts.apple.com/cn/podcast/%E8%AF%B4%E5%BE%97%E5%A5%BD%E5%90%AC/id1493363108?l=en#episodeGuid=http%3A%2F%2Faudio.xmcdn.com%2Fgroup80%2FM02%2F10%2F94%2FwKgPDF6-mzPykp-JAhW-F0k2sIo303.m4a"
+              target="_blank"
+              rel="noopener"
+              >https://podcasts.apple.com/cn/podcast/%E8%AF%B4%E5%BE%97%E5%A5%BD%E5%90%AC/id1493363108?l=en#episodeGuid=http%3A%2F%2Faudio.xmcdn.com%2Fgroup80%2FM02%2F10%2F94%2FwKgPDF6-mzPykp-JAhW-F0k2sIo303.m4a</a
+            ></span
+          >
+        </section>
+        <p>
+          <span
+            >如果你对本期节目的话题感兴趣，或者对节目有任何的想法，欢迎通过留言、微博、邮箱与我们互动。</span
+          ><br />
+        </p>
+        <p>
+          <span><span>✎&nbsp;</span>微博：@说得好听SoundsGood</span><br />
+        </p>
+        <p>
+          <span><span>✎&nbsp;</span>邮箱：haoting_soundsgood@163.com</span>
+        </p>
+        <hr />
+        <p>
+          <span
+            >博主本人和申申主播私下里也是好好朋友,
+            所以清楚她对这个音乐及泛音乐文化的谈话类播客有多么用心,
+            每一期从策划话题到准备访谈问题到找嘉宾录制,&nbsp;都是满满的想法与精力!
+            RESPECT GIRL!</span
+          >
+        </p>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/readme-intro.html
+++ b/articles/readme-intro.html
@@ -1,0 +1,387 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>「README」无痛入门音乐科技门槛须知 - 无痛入门音乐科技</title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「README」无痛入门音乐科技门槛须知</h1>
+      <div class="meta">无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            音乐科技泛指当代计算机科学与硬件技术在音乐艺术上的开发与应用。本公众号将在后续文章中，重点介绍其在音乐信息检索与新型乐器/音乐交互上的入门知识。
+          </p>
+        </blockquote>
+        <p>
+          <strong
+            >♬
+            博主强烈建议读者能大致了解本文涉及的所有概念，确保无痛跨个门槛先&nbsp;<strong
+              >♬&nbsp;</strong
+            ></strong
+          >
+        </p>
+        <hr />
+        <h3><span>『乐理』</span></h3>
+        <p>
+          无论是哪一种音乐的表征形式，都会尽量涵盖音乐中的所有元素。比较直观的当属五线谱，随便拿出拉赫玛尼诺夫前奏曲开头的两小节看一下：
+        </p>
+        <p>
+          <img
+            src="https://mmbiz.qpic.cn/mmbiz_jpg/7CrMia15fFJUoH5iclH71F2eFvLNfpKFcF07wbHTQpw7KnfWZ7icuJnc1VR05e6YvfYkFm6IMAR7XGeK21Libsepeg/640"
+          />
+        </p>
+        <p>但实际上，作曲家和演奏家可以在仅仅两小节内表达出更丰富的信息：</p>
+        <p>
+          <img
+            src="https://mmbiz.qpic.cn/mmbiz_jpg/7CrMia15fFJUoH5iclH71F2eFvLNfpKFcFRxYuo3Letl4lI8q5ZwuwC2sibTlbOa0rnGZRjbuFMibw8vEhIln2P9Bg/640"
+          /><br />
+        </p>
+        <p>
+          然而更多高层次的信息，很难仅由两小节获取，比如乐曲想表达的情绪、所属的音乐风格等等。五线谱属于一种适合我们人类去解读的一种表征形式，对于计算机来说，MusicXML和MIDI等类似“文本文件”的格式更有益于它对音乐信息的理解。
+        </p>
+        <p>
+          当然在音乐科技领域内，更多的是将音频即wav/mp3等文件作为输入，利用信号处理或当下最火的深度学习的方法，解读出该音频中音乐的“理”。比如用音高估计做听歌识曲、用声源分离做人声增强等等，甚至可以大量地对某一类型的音乐进行建模，从而实现智能自动伴奏或作曲。
+        </p>
+        <p>
+          对于博主个人来说，把乐理理解得越通透，才能更有针对性地对音乐中的不同元素进行分析建模，减轻后续任务的计算负担，这也是为什么会发明出常数Q变换(CQT)和色度特征(chroma
+          feature)等算法背后的基石。
+        </p>
+        <hr />
+        <p><span>『信号处理DSP』</span><br /></p>
+        <p>
+          上文提到的常数Q变换与色度特征，以及音频信号在时域与频域间的其他变换，打回原形来讲，都算傅里叶变换的“变种”。拥有绝对音感的人，没准儿一听到音乐就会控制不住的做起傅里叶变换，从而知道这段在时域上的音乐波形变换到频域上就是440Hz即标准音A4。
+        </p>
+        <p>
+          计算机无法像人耳般感受音乐产生的空气振动，它只能读取某一采样率下某比特的音频文件做短时傅里叶变换(STFT)，也就是将音频加窗分成若干帧，对每一帧进行离散傅里叶变换(DFT)才能得到当前帧下的频域信息。
+        </p>
+        <p>
+          音乐信息检索这门学科非常依赖信号处理的技术，博主会在以后介绍具体应用时详细介绍DSP，力争无痛！
+        </p>
+        <hr />
+        <p><span>『Python编程』</span><br /></p>
+        <p>
+          入门教程涉及的代码都将基于Python, 且GitHub上的课件大多数将用Jupyter
+          Notebook呈现。另外还会涉及一些命令行，比如用
+          <code><span>pip</span></code
+          >安装Python的若干库，用 <code><span>git</span></code
+          >下载或更新课件内容等等。
+        </p>
+        <p>为确保所有代码能在读者的电脑上跑通，博主建议：</p>
+        <ul>
+          <li>
+            <p>
+              <span
+                >用<strong>anaconda</strong>安装<strong>Python 3</strong></span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>了解Python语言的基础知识</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                >熟悉<strong>命令行</strong>的基本指令如&nbsp;<code
+                  ><span>ls</span></code
+                >&nbsp;<code><span>cd</span></code
+                >&nbsp;<code><span>pwd</span></code
+                >等等</span
+              >
+            </p>
+          </li>
+          <li>
+            <p>
+              <span
+                >注册<strong>GitHub</strong>账号，并了解&nbsp;<code
+                  ><span>git</span></code
+                >指令</span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>
+          博主在以前做助教时写过一些教程，包含以上所有知识，不过是全英文的，感兴趣的话可以参考下方链接！&nbsp;
+        </p>
+        <p>
+          <span>➥</span>
+          <span
+            ><a
+              href="https://github.com/beiciliang/ECS719-SoftwareCarpentry"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/beiciliang/ECS719-SoftwareCarpentry</a
+            ></span
+          >
+        </p>
+        <hr />
+        <h2><span>『好奇心 &amp; 好心情』</span></h2>
+        <p>
+          有人说音乐存在的意义是因为那些无法说出口的话，如果你有足够的好奇心，博主相信你可以用音乐科技多多少少估计出个大概意思！如果答案无法满足你的好奇心，好心情也能左右继续探索下去的动力。
+        </p>
+        <p>
+          也许就是这两好，博主在攻读博士学位的最后一年还能有闲情逸致开这个公众号……这也是一种回忆自己当初入门时的那些“痛”的过程，不过私心上，我更希望读者能无痛消化音乐科技的入门知识，这样等我博士论文写出来的时候，才能有更多人知道我到底做了什么吧！
+        </p>
+        <hr />
+        <h2><span>『友情链接』</span></h2>
+        <p><span>☞ </span><span>无痛入门音乐科技相关代码</span></p>
+        <p>
+          <span
+            ><span
+              >➥&nbsp;<a
+                href="https://github.com/beiciliang/intro2musictech"
+                target="_blank"
+                rel="noopener"
+                >https://github.com/beiciliang/intro2musictech</a
+              ></span
+            ><span></span
+          ></span>
+        </p>
+        <p><span>☞ </span><span>C4DM科研组官方主页</span></p>
+        <p>
+          <span
+            ><span
+              >➥&nbsp;<a
+                href="http://c4dm.eecs.qmul.ac.uk"
+                target="_blank"
+                rel="noopener"
+                >http://c4dm.eecs.qmul.ac.uk</a
+              ></span
+            ><span></span
+          ></span>
+        </p>
+        <p><span>☞ </span><span>MAT博士培养项目主页</span></p>
+        <p>
+          <span
+            ><span
+              >➥&nbsp;<a
+                href="http://www.mat.qmul.ac.uk"
+                target="_blank"
+                rel="noopener"
+                >http://www.mat.qmul.ac.uk</a
+              ></span
+            ><span></span
+          ></span>
+        </p>
+        <p><span>☞ </span><span>音乐信息检索基础(英文)</span></p>
+        <p>
+          <span
+            ><span
+              >➥&nbsp;<a
+                href="https://musicinformationretrieval.com"
+                target="_blank"
+                rel="noopener"
+                >https://musicinformationretrieval.com</a
+              ></span
+            ><span></span
+          ></span>
+        </p>
+        <p><span>☞ </span><span>音乐信息检索国际协会</span></p>
+        <p>
+          <span
+            ><span
+              >➥&nbsp;<a href="http://ismir.net" target="_blank" rel="noopener"
+                >http://ismir.net</a
+              ></span
+            ><span></span
+          ></span>
+        </p>
+        <p><span>☞ </span><span>音乐表达新接口国际会议</span></p>
+        <p>
+          <span
+            ><span
+              >➥&nbsp;<a
+                href="http://www.nime.org"
+                target="_blank"
+                rel="noopener"
+                >http://www.nime.org</a
+              ></span
+            ><span></span
+          ></span>
+        </p>
+        <p><span>☞ </span><span>全国声音与音乐技术会议</span></p>
+        <p>
+          <span
+            ><span
+              >➥&nbsp;<a
+                href="http://www.csmcw-csmt.cn"
+                target="_blank"
+                rel="noopener"
+                >http://www.csmcw-csmt.cn</a
+              ></span
+            ><span></span
+          ></span>
+        </p>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/research-groups.html
+++ b/articles/research-groups.html
@@ -1,0 +1,1028 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>「INFO」音乐科技相关科研组列表 - 无痛入门音乐科技</title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「INFO」音乐科技相关科研组列表</h1>
+      <div class="meta">无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            又到了每年各位同学着手准备申请硕士/博士项目，以及各大公司开始提前批招聘应届生的时候了！
+            为了方便大家，博主总结了一份与音乐科技相关的科研组列表，如有遗漏还请包涵！
+          </p>
+        </blockquote>
+        <p>
+          <span
+            >以下科研组按地区排列（欧洲/北美/亚洲，排名不分先后），每个组织的研究重点有所不同，可访问其官网具体查看。</span
+          >
+        </p>
+        <p>
+          <span><strong>♬ 在文章的最后还有份小惊喜哟！♬</strong></span>
+        </p>
+        <hr />
+        <h3>『英国及欧洲地区』</h3>
+        <p>✎ Centre for Digital Music (C4DM)</p>
+        <ul>
+          <li>
+            <p><span>Queen Mary University of London</span></p>
+          </li>
+          <li>
+            <p><span>London, Uk</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="http://c4dm.eecs.qmul.ac.uk"
+                  target="_blank"
+                  rel="noopener"
+                  >http://c4dm.eecs.qmul.ac.uk</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Embodied AudioVisual Interaction Group (EAVI)</p>
+        <ul>
+          <li>
+            <p><span>Goldsmiths, University of London</span></p>
+          </li>
+          <li>
+            <p><span>London, UK</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="http://eavi.goldsmithsdigital.com"
+                  target="_blank"
+                  rel="noopener"
+                  >http://eavi.goldsmithsdigital.com</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Music Informatics Research Group</p>
+        <ul>
+          <li>
+            <p><span>City University London</span></p>
+          </li>
+          <li>
+            <p><span>London, UK</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a href="http://mirg.city.ac.uk" target="_blank" rel="noopener"
+                  >http://mirg.city.ac.uk</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Centre for Music and Science (CMS)</p>
+        <ul>
+          <li>
+            <p><span>University of Cambridge</span></p>
+          </li>
+          <li>
+            <p><span>Cambridge, UK</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="https://cms.mus.cam.ac.uk"
+                  target="_blank"
+                  rel="noopener"
+                  >https://cms.mus.cam.ac.uk</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Music Technology Group (MTG)</p>
+        <ul>
+          <li>
+            <p><span>Universitat Pompeu Fabra</span></p>
+          </li>
+          <li>
+            <p><span>Barcelona, Spain</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="https://www.upf.edu/web/mtg"
+                  target="_blank"
+                  rel="noopener"
+                  >https://www.upf.edu/web/mtg</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Department of Computational Perception</p>
+        <ul>
+          <li>
+            <p><span>Johannes Kepler University Linz</span></p>
+          </li>
+          <li>
+            <p><span>Linz, Austria</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="https://www.jku.at/en/institute-of-computational-perception/"
+                  target="_blank"
+                  rel="noopener"
+                  >https://www.jku.at/en/institute-of-computational-perception/</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>
+          ✎ Intelligent Music Processing and Machine Learning Group (IMP/ML)
+        </p>
+        <ul>
+          <li>
+            <p>
+              <span
+                >Austrian Research Institute for Artificial Intelligence
+                (OFAI)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>Vienna, Austria</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="http://www.ofai.at/research/impml/index.html"
+                  target="_blank"
+                  rel="noopener"
+                  >http://www.ofai.at/research/impml/index.html</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Music Information Retrieval Lab</p>
+        <ul>
+          <li>
+            <p><span>Vienna University of Technology</span></p>
+          </li>
+          <li>
+            <p><span>Vienna, Austria</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="http://www.ifs.tuwien.ac.at/mir/"
+                  target="_blank"
+                  rel="noopener"
+                  >http://www.ifs.tuwien.ac.at/mir/</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Institute for Electronic Music and Acoustics (IEM)</p>
+        <ul>
+          <li>
+            <p><span>University of Music and Performing Arts Graz</span></p>
+          </li>
+          <li>
+            <p><span>Graz, Austria</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="https://iem.kug.ac.at/en/institute-of-electronic-music-and-acoustics.html"
+                  target="_blank"
+                  rel="noopener"
+                  >https://iem.kug.ac.at/en/institute-of-electronic-music-and-acoustics.html</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ International Audio Laboratories Erlangen (AudioLabs)</p>
+        <ul>
+          <li>
+            <p>
+              <span
+                >Fraunhofer IIS and Friedrich-Alexander-Universität
+                Erlangen-Nürnberg (FAU)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>Erlangen, Germany</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="https://www.audiolabs-erlangen.de"
+                  target="_blank"
+                  rel="noopener"
+                  >https://www.audiolabs-erlangen.de</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Special Interest Group on Music Analysis (SIGMA)</p>
+        <ul>
+          <li>
+            <p><span>Technische Universität Dortmund</span></p>
+          </li>
+          <li>
+            <p><span>Dortmund, Germany</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a href="http://sig-ma.de" target="_blank" rel="noopener"
+                  >http://sig-ma.de</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>
+          ✎ Institute for Research and Coordination in Acoustics/Music (IRCAM)
+        </p>
+        <ul>
+          <li>
+            <p><span>Paris, France</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a href="https://www.ircam.fr" target="_blank" rel="noopener"
+                  >https://www.ircam.fr</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Audio Data Analysis and Signal Processing (ADASP)</p>
+        <ul>
+          <li>
+            <p><span>Telecom ParisTech</span></p>
+          </li>
+          <li>
+            <p><span>Paris, France</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="http://www.tsi.telecom-paristech.fr/aao/en/"
+                  target="_blank"
+                  rel="noopener"
+                  >http://www.tsi.telecom-paristech.fr/aao/en/</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Algomus</p>
+        <ul>
+          <li>
+            <p><span>Lille, France</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a href="http://www.algomus.fr" target="_blank" rel="noopener"
+                  >http://www.algomus.fr</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Audio Signal Processing Research Group</p>
+        <ul>
+          <li>
+            <p><span>Aalto University</span></p>
+          </li>
+          <li>
+            <p><span>Aalto, Finland</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="http://spa.aalto.fi/en/research/research"
+                  target="_blank"
+                  rel="noopener"
+                  >http://spa.aalto.fi/en/research/research</a
+                ><span>groups/audio</span>signal_processing/</span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Department of Music, Art and Culture Studies</p>
+        <ul>
+          <li>
+            <p><span>University of Jyväskylä</span></p>
+          </li>
+          <li>
+            <p><span>Jyväskylä, Finland</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="https://www.jyu.fi/hytk/fi/laitokset/mutku/en"
+                  target="_blank"
+                  rel="noopener"
+                  >https://www.jyu.fi/hytk/fi/laitokset/mutku/en</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Audio Analysis Lab</p>
+        <ul>
+          <li>
+            <p><span>Aalborg University</span></p>
+          </li>
+          <li>
+            <p><span>Aalborg, Denmark</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="https://audio.create.aau.dk"
+                  target="_blank"
+                  rel="noopener"
+                  >https://audio.create.aau.dk</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Multimedia and Geometry (MG)</p>
+        <ul>
+          <li>
+            <p><span>Utrecht University</span></p>
+          </li>
+          <li>
+            <p><span>Utrecht, Netherlands</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="http://www.cs.uu.nl/groups/MG/"
+                  target="_blank"
+                  rel="noopener"
+                  >http://www.cs.uu.nl/groups/MG/</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Institute for Psychoacoustics and Electronic Music (IPEM)</p>
+        <ul>
+          <li>
+            <p><span>Ghent University</span></p>
+          </li>
+          <li>
+            <p><span>Ghent, Belgium</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="https://www.ugent.be/lw/kunstwetenschappen/en/research-groups/musicology/ipem"
+                  target="_blank"
+                  rel="noopener"
+                  >https://www.ugent.be/lw/kunstwetenschappen/en/research-groups/musicology/ipem</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ MIR Group</p>
+        <ul>
+          <li>
+            <p><span>University of Coimbra</span></p>
+          </li>
+          <li>
+            <p><span>Coimbra, Portugal</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="http://mir.dei.uc.pt/index.html"
+                  target="_blank"
+                  rel="noopener"
+                  >http://mir.dei.uc.pt/index.html</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <hr />
+        <h3>『北美地区』</h3>
+        <p>
+          ✎ Centre of Interdisciplinary Research in Music Media and Technology
+          (CIRMMT)
+        </p>
+        <ul>
+          <li>
+            <p><span>McGill University</span></p>
+          </li>
+          <li>
+            <p><span>Montreal, Canada</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a href="http://www.cirmmt.org" target="_blank" rel="noopener"
+                  >http://www.cirmmt.org</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Center for Computer Research in Music and Acoustics (CCRMA)</p>
+        <ul>
+          <li>
+            <p><span>Stanford University</span></p>
+          </li>
+          <li>
+            <p><span>Standford, USA</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="https://ccrma.stanford.edu"
+                  target="_blank"
+                  rel="noopener"
+                  >https://ccrma.stanford.edu</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Music and Audio Research Laboratory (MARL)</p>
+        <ul>
+          <li>
+            <p><span>New York University</span></p>
+          </li>
+          <li>
+            <p><span>New York City, USA</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="https://steinhardt.nyu.edu/marl/"
+                  target="_blank"
+                  rel="noopener"
+                  >https://steinhardt.nyu.edu/marl/</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>
+          ✎ Laboratory for the Recognition and Organization of Speech and Audio
+          (LabROSA)
+        </p>
+        <ul>
+          <li>
+            <p><span>Columbia University</span></p>
+          </li>
+          <li>
+            <p><span>New York City, USA</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="https://labrosa.ee.columbia.edu"
+                  target="_blank"
+                  rel="noopener"
+                  >https://labrosa.ee.columbia.edu</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Georgia Tech Center for Music Technology (GTCMT)</p>
+        <ul>
+          <li>
+            <p><span>Georgia Institute of Technology</span></p>
+          </li>
+          <li>
+            <p><span>Atlanta, USA</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="http://www.gtcmt.gatech.edu"
+                  target="_blank"
+                  rel="noopener"
+                  >http://www.gtcmt.gatech.edu</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Computer Music Project (CMP)</p>
+        <ul>
+          <li>
+            <p><span>Carnegie Mellon University (CMU)</span></p>
+          </li>
+          <li>
+            <p><span>Pittsburgh, USA</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="http://www.cs.cmu.edu/%7Emusic/"
+                  target="_blank"
+                  rel="noopener"
+                  >http://www.cs.cmu.edu/%7Emusic/</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Soundlab</p>
+        <ul>
+          <li>
+            <p><span>Princeton University</span></p>
+          </li>
+          <li>
+            <p><span>Princeton, USA</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="http://soundlab.cs.princeton.edu"
+                  target="_blank"
+                  rel="noopener"
+                  >http://soundlab.cs.princeton.edu</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Music and Entertainment Technology Laboratory (MET-lab)</p>
+        <ul>
+          <li>
+            <p><span>Drexel University</span></p>
+          </li>
+          <li>
+            <p><span>Philadelphia, USA</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a href="http://www.met-lab.org" target="_blank" rel="noopener"
+                  >http://www.met-lab.org</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Music Engineering</p>
+        <ul>
+          <li>
+            <p><span>University of Miami</span></p>
+          </li>
+          <li>
+            <p><span>Coral Gables, USA</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="http://mue.music.miami.edu"
+                  target="_blank"
+                  rel="noopener"
+                  >http://mue.music.miami.edu</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Bregman Media Labs</p>
+        <ul>
+          <li>
+            <p><span>Dartmouth College</span></p>
+          </li>
+          <li>
+            <p><span>Hanover, USA</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="http://bregman.dartmouth.edu"
+                  target="_blank"
+                  rel="noopener"
+                  >http://bregman.dartmouth.edu</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ The Media Lab</p>
+        <ul>
+          <li>
+            <p><span>Massachusetts Institute of Technology (MIT)</span></p>
+          </li>
+          <li>
+            <p><span>Cambridge, USA</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="https://www.media.mit.edu"
+                  target="_blank"
+                  rel="noopener"
+                  >https://www.media.mit.edu</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Center for New Music and Audio Technologies (CNMAT)</p>
+        <ul>
+          <li>
+            <p><span>UC Berkeley</span></p>
+          </li>
+          <li>
+            <p><span>Berkeley, USA</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="http://cnmat.berkeley.edu"
+                  target="_blank"
+                  rel="noopener"
+                  >http://cnmat.berkeley.edu</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Center for Research in Electronic Art Technology (CREATE)</p>
+        <ul>
+          <li>
+            <p><span>UCSB</span></p>
+          </li>
+          <li>
+            <p><span>Santa Barbara, USA</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="http://www.create.ucsb.edu"
+                  target="_blank"
+                  rel="noopener"
+                  >http://www.create.ucsb.edu</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <hr />
+        <h3>『亚洲地区』</h3>
+        <p>✎ Multimedia Information Retrieval Lab</p>
+        <ul>
+          <li>
+            <p><span>National Taiwan University, Taiwan</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a href="http://mirlab.org" target="_blank" rel="noopener"
+                  >http://mirlab.org</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Music and Audio Computing Lab (MAC)</p>
+        <ul>
+          <li>
+            <p><span>Academia Sinica, Taiwan</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="http://mac.iis.sinica.edu.tw"
+                  target="_blank"
+                  rel="noopener"
+                  >http://mac.iis.sinica.edu.tw</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Media Interaction Group</p>
+        <ul>
+          <li>
+            <p>
+              <span
+                >National Institute of Advanced Industrial Science and
+                Technology (AIST)</span
+              >
+            </p>
+          </li>
+          <li>
+            <p><span>Japan</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="https://staff.aist.go.jp/m.goto/MIG/index-j.html"
+                  target="_blank"
+                  rel="noopener"
+                  >https://staff.aist.go.jp/m.goto/MIG/index-j.html</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Music and Audio Computing Lab</p>
+        <ul>
+          <li>
+            <p>
+              <span>Korea Advanced Institute of Science and Technology</span>
+            </p>
+          </li>
+          <li>
+            <p><span>Korea</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a href="http://mac.kaist.ac.kr" target="_blank" rel="noopener"
+                  >http://mac.kaist.ac.kr</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Sound and Music Computing Lab</p>
+        <ul>
+          <li>
+            <p><span>National University of Singapore</span></p>
+          </li>
+          <li>
+            <p><span>Singapore</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a href="https://www.smcnus.org" target="_blank" rel="noopener"
+                  >https://www.smcnus.org</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <p>✎ Music Cognition Group</p>
+        <ul>
+          <li>
+            <p>
+              <span>Agency for Science, Technology and Research (A*STAR)</span>
+            </p>
+          </li>
+          <li>
+            <p><span>Singapore</span></p>
+          </li>
+          <li>
+            <p>
+              <span
+                ><a
+                  href="https://www.a-star.edu.sg/ihpc/Research/Social-Cognitive-Computing-SCC/Music-Cognition/Overview-and-Recent-Highlights"
+                  target="_blank"
+                  rel="noopener"
+                  >https://www.a-star.edu.sg/ihpc/Research/Social-Cognitive-Computing-SCC/Music-Cognition/Overview-and-Recent-Highlights</a
+                ></span
+              >
+            </p>
+          </li>
+        </ul>
+        <hr />
+        <p>
+          该行业在国内得益于全国声音与音乐技术会议（CSMT）的召开，使得学术界与工业界的朋友们可以借此互相交流，博主也有幸在天津大学读本科时，跟随关欣老师和梁晓晶学姐一起参加了2013年的第一届会议。
+        </p>
+        <p>会议官网上可下载往届报告集和论文集：</p>
+        <p>
+          <span
+            >➥
+            <a
+              href="http://www.csmcw-csmt.cn/index.html"
+              target="_blank"
+              rel="noopener"
+              >http://www.csmcw-csmt.cn/index.html</a
+            ></span
+          >
+        </p>
+      </div>
+    </article>
+  </body>
+</html>

--- a/articles/setup-environment.html
+++ b/articles/setup-environment.html
@@ -1,0 +1,535 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>「SETUP」从零设置编程环境 - 无痛入门音乐科技</title>
+    <style>
+      :root {
+        --bg: #f5f5f7;
+        --card-bg: #ffffff;
+        --text: #1d1d1f;
+        --text-secondary: #6e6e73;
+        --accent: #5856d6;
+        --border: #d2d2d7;
+        --code-bg: #f0f0f3;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --bg: #0d0d12;
+          --card-bg: #1c1c24;
+          --text: #f0f0f5;
+          --text-secondary: #8e8e93;
+          --accent: #7b79ff;
+          --border: #2c2c34;
+          --code-bg: #15151d;
+        }
+      }
+      * {
+        margin: 0;
+        padding: 0;
+        box-sizing: border-box;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+          Roboto, "Noto Sans SC", sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.8;
+      }
+      .header {
+        background: linear-gradient(
+          135deg,
+          #0f0c29 0%,
+          #302b63 50%,
+          #24243e 100%
+        );
+        padding: 2rem 1.5rem;
+        text-align: center;
+      }
+      .header a {
+        color: rgba(255, 255, 255, 0.7);
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .header a:hover {
+        color: #fff;
+      }
+      article {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 4rem;
+      }
+      article h1 {
+        font-size: 1.8rem;
+        font-weight: 700;
+        margin-bottom: 0.5rem;
+        line-height: 1.3;
+      }
+      .meta {
+        color: var(--text-secondary);
+        font-size: 0.85rem;
+        margin-bottom: 2rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .content {
+        font-size: 1rem;
+      }
+      .content p,
+      .content section {
+        margin-bottom: 1rem;
+      }
+      .content img {
+        max-width: 100%;
+        height: auto;
+        border-radius: 8px;
+        margin: 1rem 0;
+      }
+      .content h2,
+      .content h3 {
+        text-align: center;
+        margin: 1.5rem 0 0.8rem;
+        font-weight: 600;
+      }
+      .content blockquote {
+        border-left: 3px solid var(--accent);
+        padding-left: 1rem;
+        color: var(--text-secondary);
+        margin: 1rem 0;
+      }
+      .content a {
+        color: var(--accent);
+      }
+      .content hr {
+        border: none;
+        border-top: 1px solid var(--border);
+        margin: 1.5rem 0;
+      }
+      .content ul,
+      .content ol {
+        padding-left: 1.5rem;
+        margin-bottom: 1rem;
+      }
+      .content li {
+        margin-bottom: 0.3rem;
+      }
+      .content table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+      }
+      .content th,
+      .content td {
+        border: 1px solid var(--border);
+        padding: 0.5rem;
+        text-align: left;
+      }
+      .content pre,
+      .content code {
+        font-family:
+          "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono",
+          monospace;
+        font-size: 0.85em;
+      }
+      .content code {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 4px;
+        padding: 0.15rem 0.4rem;
+      }
+      .content pre {
+        background: var(--code-bg);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 1rem 1.2rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+        line-height: 1.5;
+      }
+      .content pre code {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: inherit;
+        display: block;
+      }
+      .content pre ol {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+      .content pre li {
+        margin: 0;
+        padding: 0;
+      }
+      .content pre p {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <a href="../index.html">&larr; 返回 无痛入门音乐科技</a>
+    </div>
+    <article>
+      <h1>「SETUP」从零设置编程环境</h1>
+      <div class="meta">无痛入门音乐科技</div>
+      <div class="content">
+        <blockquote>
+          <p>
+            本文适用于编程零基础的读者，如果你已经清楚如何
+            <code><span>git clone</span></code
+            >本项目，并能在一个基于Python 3.7的虚拟环境内安装
+            <code><span>requirements.txt</span></code
+            >后，不报错地加载本文 <code><span>JupyterNotebook</span></code
+            >部分中的 <code><span>00-Hello.ipynb</span></code
+            >，恭喜你，编程环境配置成功！
+          </p>
+        </blockquote>
+        <p>
+          <span><strong>以后博主发了新的公众号文章</strong></span>
+        </p>
+        <p>
+          <span><strong>其ipynb格式会在GitHub上同步更新</strong></span>
+        </p>
+        <p>
+          <span
+            ><strong>方便读者在自己的电脑上一边阅读一边执行代码</strong></span
+          >
+        </p>
+        <p>
+          <span><strong>♬&nbsp; 快速入门，无痛skr ♬&nbsp;</strong></span>
+        </p>
+        <p>
+          <span>☞ 点击最下方</span><strong>阅读原文</strong
+          ><span>即下方链接进入本文GitHub页获取相关文件:</span>
+        </p>
+        <p>
+          <span
+            >➥&nbsp;<a
+              href="https://github.com/beiciliang/intro2musictech/blob/master/README.md"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/beiciliang/intro2musictech/blob/master/README.md</a
+            ></span
+          >
+        </p>
+        <p>本文将涵盖:<br /></p>
+        <ol>
+          <li>
+            <p><span>命令行基础操作</span></p>
+          </li>
+          <li>
+            <p><span>Git用法</span></p>
+          </li>
+          <li>
+            <p><span>Anaconda设置环境</span></p>
+          </li>
+          <li>
+            <p><span>用Jupyter Notebook运行Python代码</span></p>
+          </li>
+          <li>
+            <p><span>如何退出</span></p>
+          </li>
+          <li>
+            <p><span>后续工作</span></p>
+          </li>
+        </ol>
+        <hr />
+        <h3>『命令行』</h3>
+        <p>
+          在计算机还没有酷炫的交互界面甚至连鼠标都没有的年代，人们通过命令行来操作程序，如果你学会了在命令行下如何操作，表面上能看起来像个黑客，实际上能大大加快操作速度。
+        </p>
+        <p>
+          假如你是MacOS或Linux用户，博主希望你懂得如何使用终端(Terminal)；假如你是Windows用户，则希望你懂得如何使用命令窗口(Command
+          Prompt)或PowerShell。<strong>以下内容以在MacOS上操作为例！</strong>
+        </p>
+        <p>
+          ✎ 打开终端界面后，应该会看到一个白色或黑色的窗口，正等待着你的命令：
+        </p>
+        <pre><ol><li><p><span><code><span>HOSTNAME:~ USER$ </span></code></span></p></li></ol></pre>
+        <p>
+          其中<code><span>HOSTNAME</span></code
+          >的部分指主机名，冒号后的<code><span>~</span></code
+          >表示当前路径在根目录下，<code><span>USER</span></code
+          >是用户名，最后<code><span>$</span></code
+          >提示终端在等待你输入命令。本文将主要用到<code><span>ls</span></code>
+          <code><span>cd</span></code> <code><span>pwd</span></code>
+          <code><span>git</span></code> <code><span>conda</span></code>
+          <code><span>pip</span></code> 这些命令。
+        </p>
+        <p>
+          ✎ 首先<code><span>ls</span></code
+          >表示列出当前路径下的所有文件：
+        </p>
+        <pre><ol><li><p><span><code><span>HOSTNAME:~ USER$ ls</span></code></span></p></li></ol></pre>
+        <p>输入后回车，窗口中会返回所有文件和文件夹的名字。</p>
+        <p>
+          ✎ 假设一个叫<code><span>Downloads</span></code
+          >的文件夹在上述返回的名字列表中，进入这个文件夹需要
+          <code><span>cd</span></code
+          >：
+        </p>
+        <pre><ol><li><p><span><code><span>HOSTNAME:~ USER$ cd </span><span>Downloads</span></code></span></p></li></ol></pre>
+        <p>
+          ✎ 回车后“当前路径”已经由<code><span>~</span></code
+          >变成这个文件夹的位置，输入<code><span>pwd</span></code
+          >可以再确认：
+        </p>
+        <pre><ol><li><p><span><code><span>HOSTNAME:</span><span>Downloads</span><span> USER$ pwd</span></code></span></p></li></ol></pre>
+        <p>回车后会显示当前路径为</p>
+        <pre><ol><li><p><span><code><span>/Users/</span><span>USER/</span><span>Downloads</span></code></span></p></li></ol></pre>
+        <p>
+          ✎ 如果需要返回上一级目录，依然可以使用 <code><span>cd</span></code
+          >：
+        </p>
+        <pre><ol><li><p><span><code><span>HOSTNAME:</span><span>Downloads</span><span> USER$ cd ..</span></code></span></p></li></ol></pre>
+        <p>
+          这些就是最最基本的命令行了！下面的部分会继续讲解其他命令行的用法，需要时刻注意路径是否正确，指令之间是否有空格分隔等等。
+        </p>
+        <hr />
+        <h3>『Git用法』</h3>
+        <p>
+          Git即版本控制，是一种记录一个或若干文件内容变化，以便将来查阅特定版本修订情况的系统。程序员们用它才能最快发现到底是谁在什么时候删了一行不该删的代码。
+        </p>
+        <p>
+          公众号涉及的代码都是由博主先在自己的电脑上通过git进行本地版本控制，再托管到Github这个可以让读者们看到的地方。如果有错误的地方，其他人也可以发起<code
+            ><span>pull request</span></code
+          >来纠正，博主再<code><span>git merge</span></code
+          >把别人的修改意见融到自己的代码中。
+        </p>
+        <p>✎ 首先需要将Git安装在你的计算机上，安装指南链接如下：</p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://git-scm.com/book/zh/v2/%E8%B5%B7%E6%AD%A5-%E5%AE%89%E8%A3%85-Git"
+              target="_blank"
+              rel="noopener"
+              >https://git-scm.com/book/zh/v2/%E8%B5%B7%E6%AD%A5-%E5%AE%89%E8%A3%85-Git</a
+            ></span
+          >
+        </p>
+        <p>✎ 其次，你需要一个GitHub账号，这也能方便将来对自己代码的托管。</p>
+        <p>✎ 之后你可以通过Git命令行，将公众号的代码克隆到你的计算机上：</p>
+        <pre><ol><li><p><span><code><span>HOSTNAME:~ USER$ git clone https:</span><span>//github.com/beiciliang/intro2musictech.git</span></code></span></p></li></ol></pre>
+        <p>
+          克隆完成后若在当前路径下输入&nbsp;<code><span>ls</span></code
+          >，返回的名单中将包含<code><span>intro2musictech</span></code
+          >。
+        </p>
+        <p>
+          因为公众号的代码会随新文章的发布而增加更多内容，博主建议读者发现有新文章发布后通过<code
+            ><span>git pull</span></code
+          >来同步更新。
+        </p>
+        <p>
+          ☞ 如果实在觉得各种git指令太晦涩，可通过GitHub
+          Desktop软件进行版本控制。
+        </p>
+        <p>
+          ☞
+          如果想更深入了解git和GitHub，英文好的读者可直接参考官方帮助文档，中文资料可参考：
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://github.com/xirong/my-git/blob/master/how-to-use-github.md"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/xirong/my-git/blob/master/how-to-use-github.md</a
+            ></span
+          ><span></span>
+        </p>
+        <hr />
+        <h3>『Anaconda设置环境』</h3>
+        <p>
+          现在通过 <code><span>ls</span></code
+          >查看一下<code><span>intro2musictech</span></code
+          >文件夹里都有哪些东东:
+        </p>
+        <pre><ol><li><p><span><code><span>HOSTNAME:~ USER$ ls intro2musictech</span></code></span></p></li></ol></pre>
+        <p>
+          其中<code><span>attachment</span></code
+          >文件夹里包含一些音乐素材和图片，以 <code><span>.ipynb</span></code
+          >为后缀的文件都是Jupyter Notebook，重点是<code
+            ><span>requirements.txt</span></code
+          >中所有的Python库，成功安装这些才能确保今后所有
+          <code><span>.ipynb</span></code
+          >中的Python代码能跑起来。
+        </p>
+        <p>不过首先需要解决的大事儿是，如何安装Python？</p>
+        <p>
+          我们可借助Anaconda，即一个预装了很多我们用的到或用不到的第三方库的Python。
+        </p>
+        <p>
+          ✎
+          首先去官网根据自己系统的型号，下载<strong>Anaconda3</strong>并安装，但是国内的同学也许会发现官网下载太慢，这种情况可从国内清华大学开源软件镜像站进行下载并配置镜像:
+        </p>
+        <p>☞ 官方下载链接</p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://www.anaconda.com/download/"
+              target="_blank"
+              rel="noopener"
+              >https://www.anaconda.com/download/</a
+            ></span
+          >
+        </p>
+        <p>☞ 清华大学镜像站</p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://mirrors.tuna.tsinghua.edu.cn/anaconda/archive/"
+              target="_blank"
+              rel="noopener"
+              >https://mirrors.tuna.tsinghua.edu.cn/anaconda/archive/</a
+            ></span
+          >
+        </p>
+        <p>
+          ✎
+          安装过程中，建议勾选把Anaconda加入环境变量，并设置Anaconda所带的Python
+          3.6为系统默认的Python版本，不过这些步骤不做问题也不大，反正之后我们要建立一个新的Python
+          3.7虚拟环境！
+        </p>
+        <p>
+          <strong>另</strong
+          >，建议国内读者通过镜像成功安装Anaconda之后，修改其包管理镜像为国内源，即运行下方两个命令行：
+        </p>
+        <pre><ol><li><p><span><code><span>$ conda config --add channels https:</span><span>//mirrors.tuna.tsinghua.edu.cn/anaconda/pkgs/free/</span></code></span></p></li><li><p><span><code><span>$ conda config --</span><span>set</span><span> show_channel_urls yes</span></code></span></p></li></ol></pre>
+        <p>
+          ✎
+          安装Anaconda后，用它建立虚拟环境可以指定要安装在环境中的Python版本和第三方库，避免在自己的电脑上瞎安装/起冲突/费时间，这对需要同时用Python版本2和3的程序员非常有必要！
+        </p>
+        <p>✎ 下面的命令行将一步步带领读者走向成功的一半！</p>
+        <p>
+          A. 先用<code><span>conda</span></code
+          >安装个环境自动关联包：
+        </p>
+        <pre><ol><li><p><span><code><span>$ conda install nb_conda</span></code></span></p></li></ol></pre>
+        <p>
+          B. 建立一个名字为<code><span>py37</span></code
+          >的环境，该环境下Python版本为3.7，并安装<code
+            ><span>ipykernel</span></code
+          >这个库也就顺便将Jupyther Notebook安装到<code><span>py37</span></code
+          >环境中：
+        </p>
+        <pre><ol><li><p><span><code><span>$ conda create -n py37 python=</span><span>3.7</span><span> ipykernel</span></code></span></p></li></ol></pre>
+        <p>
+          C. 激活<code><span>py37</span></code
+          >环境：
+        </p>
+        <pre><ol><li><p><span><code><span>$ source activate py37</span></code></span></p></li></ol></pre>
+        <p>激活后可见命令行开头有括号提示你已经在括号内显示的虚拟环境中。</p>
+        <p>
+          D. 在该虚拟环境下用<code><span>pip</span></code
+          >安装其他第三方库（先升级下<code><span>pip</span></code
+          >）：
+        </p>
+        <pre><ol><li><p><span><code><span>(py37)$ pip install --upgrade pip</span></code></span></p></li><li><p><span><code><span>(py37)$ pip install numpy scipy matplotlib librosa scikit-learn</span></code></span></p></li></ol></pre>
+        <p><strong>另</strong>，这些库也可通过指令：</p>
+        <p>
+          <code><span>pip install-r requirements.txt</span></code>
+        </p>
+        <p>
+          来安装，注意除非当前路径与该txt文件相同，否则要在指令中声明txt所在的具体路径！
+        </p>
+        <p>
+          对于第三方库的安装，用<code><span>pip</span></code
+          >或<code><span>conda</span></code
+          >其实没有大区别，但博主一般会参考这个库本身建议哪种方式最简单。
+        </p>
+        <p>
+          E. 此时你可通过<code><span>conda list</span></code
+          >指令来查看<code><span>py37</span></code
+          >环境下具体成功安装上了哪些库。
+        </p>
+        <p>
+          F. 若想退出虚拟环境，可直接输入<code
+            ><span>source deactivate</span></code
+          >后回车，不过为了最后关于Notebook的环节，暂且先不要退出！
+        </p>
+        <hr />
+        <h3>『用Jupyter Notebook运行Python』</h3>
+        <p>
+          Jupyter
+          Notebook本身是一种网页端应用，能让用户将说明文本、数学方程、代码和可视化内容全部组合到一个易于共享的文档中。
+        </p>
+        <p>
+          ✎ 现在我们在 <code><span>py37</span></code
+          >虚拟环境下直接用命令行打开该应用：
+        </p>
+        <pre><ol><li><p><span><code><span>(py37)$ jupyter notebook</span></code></span></p></li></ol></pre>
+        <p>
+          此时你的浏览器应该会直接弹出一个新页面，你也可以粘贴命令行返回的URL链接，拷贝到浏览器中打开应用。
+        </p>
+        <p>
+          ✎ 点击页面右侧的<code><span>New</span></code
+          >并选择<code><span>Python[conda env:py37]</span></code
+          >可新建一个基于该虚拟环境的Notebook。
+        </p>
+        <p>
+          ✎ 现在我们回到之前的页面，进入<code><span>intro2musictech</span></code
+          >文件夹后打开<code><span>00-Hello.ipynb</span></code
+          >文件。
+        </p>
+        <p>
+          ✎ 读者也可通过下方链接浏览<code><span>00-Hello.ipynb</span></code
+          >的内容。
+        </p>
+        <p>
+          <span
+            >➥
+            <a
+              href="https://github.com/beiciliang/intro2musictech/blob/master/00-Hello.ipynb"
+              target="_blank"
+              rel="noopener"
+              >https://github.com/beiciliang/intro2musictech/blob/master/00-Hello.ipynb</a
+            ></span
+          >
+        </p>
+        <p>✎ 其中简要介绍了Notebook在跑Python代码时的妙用。</p>
+        <hr />
+        <h3>『如何退出』</h3>
+        <p>
+          ✎
+          关闭Notebook不仅仅要关闭浏览器页面，在其运行的命令行界面，要通过两次<code
+            ><span>CTRL+C</span></code
+          >中止程序。
+        </p>
+        <p>
+          ✎ 通过<code><span>source deactivate</span></code
+          >命令行退出当前虚拟环境。
+        </p>
+        <p>
+          ✎ 以后若需要再次激活某个虚拟环境但不巧忘了其名字，可通过<code
+            ><span>conda env list</span></code
+          >指令来查询。
+        </p>
+        <p>
+          ✎ 慎重！要是对这个<code><span>py37</span></code
+          >虚拟环境不爽，可以用<code><span>conda env remove-n py37</span></code
+          >彻底删除。
+        </p>
+        <hr />
+        <h3>『后续工作』</h3>
+        <p>
+          假设上述所有步骤都能成功执行，那么一旦有新文章时，读者可以在自己的电脑上获取更新后查看最新的Notebook，大致流程如下：
+        </p>
+        <pre><ol><li><p><span><code><span>$ cd intro2musictech</span></code></span></p></li><li><p><span><code><span>$ git pull</span></code></span></p></li><li><p><span><code><span>$ source activate py37</span></code></span></p></li><li><p><span><code><span>(py37)$ jupyter notebook</span></code></span></p></li></ol></pre>
+        <hr />
+        <p>
+          <span><strong>♬ 点击左下方阅读原文</strong></span
+          ><span><strong>进入本文GitHub关联页获取原资料 ♬</strong></span>
+        </p>
+      </div>
+    </article>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -130,12 +130,19 @@
 
     /* ── Content ── */
     .container {
-      max-width: 760px;
+      max-width: 920px;
       margin: -2rem auto 0;
       padding: 0 1.5rem 4rem;
       position: relative;
       z-index: 1;
       flex: 1;
+      display: flex;
+      gap: 1.2rem;
+      align-items: flex-start;
+    }
+    .cards {
+      flex: 1;
+      min-width: 0;
     }
 
     /* ── Card ── */
@@ -228,6 +235,53 @@
     }
     div.card h2 a:hover { color: var(--accent); }
 
+    /* ── Filter sidebar ── */
+    .filters {
+      position: sticky;
+      top: 1.5rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+      flex-shrink: 0;
+      width: 72px;
+    }
+    .filter-btn {
+      appearance: none;
+      border: 1px solid var(--border);
+      background: var(--card-bg);
+      color: var(--text-secondary);
+      font-family: inherit;
+      font-size: 0.75rem;
+      font-weight: 500;
+      padding: 0.4rem 0;
+      border-radius: 8px;
+      cursor: pointer;
+      transition: all 0.2s;
+      text-align: center;
+    }
+    .filter-btn:hover {
+      border-color: var(--accent);
+      color: var(--accent);
+    }
+    .filter-btn.active {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: #fff;
+    }
+    .card.hidden {
+      display: none;
+    }
+    @media (max-width: 640px) {
+      .container { flex-direction: column; }
+      .filters {
+        position: static;
+        flex-direction: row;
+        flex-wrap: wrap;
+        width: auto;
+      }
+      .filter-btn { padding: 0.35rem 0.75rem; }
+    }
+
   </style>
 </head>
 <body>
@@ -268,315 +322,400 @@
     </svg>
   </div>
   <main class="container">
+    <div class="filters">
+      <button class="filter-btn active" data-filter="all">全部</button>
+      <button class="filter-btn" data-filter="mir">MIR</button>
+      <button class="filter-btn" data-filter="info">INFO</button>
+      <button class="filter-btn" data-filter="tech">TECH</button>
+      <button class="filter-btn" data-filter="nime">NIME</button>
+      <button class="filter-btn" data-filter="other">OTHER</button>
+    </div>
+    <div class="cards">
     <!-- 2026-02-15 TECH -->
-    <a class="card" href="https://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247484032&idx=1&sn=02b93aa8c86730083c2bf3004fa680c1&scene=19&poc_token=HG4xkmmjershfKlaODZCAW8rQfMNzyXXIPHky1zU" target="_blank">
+    <div class="card" data-tag="tech">
       <div class="card-top">
         <span class="tag tag-tech">TECH</span>
         <span class="card-date">2026-02-15</span>
       </div>
-      <h2>过年好！分享一个可速度分析AI论文的技能指令: /ai-paper-reader</h2>
-    </a>
+      <h2><a href="articles/ai-paper-reader.html">过年好！分享一个可速度分析AI论文的技能指令: /ai-paper-reader</a></h2>
+      <div class="card-links">
+        <a href="https://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247484032&idx=1&sn=02b93aa8c86730083c2bf3004fa680c1&scene=19&poc_token=HG4xkmmjershfKlaODZCAW8rQfMNzyXXIPHky1zU" target="_blank">公众号文章</a>
+      </div>
+    </div>
     <!-- 2026-02-14 INFO — has extra links -->
-    <div class="card">
+    <div class="card" data-tag="info">
       <div class="card-top">
         <span class="tag tag-info">INFO</span>
         <span class="card-date">2026-02-14</span>
       </div>
-      <h2><a href="https://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247484022&idx=1&sn=94535fbc6c7a56490dd52d11f0962f4d&scene=19&poc_token=HFgzkmmjmF53Hz5-bJCS3mDASmeI4RhAuTrEu65S" target="_blank">连接音乐音频与自然语言（2024 ISMIR Tutorial）</a></h2>
+      <h2><a href="articles/music-language-tutorial.html">连接音乐音频与自然语言（2024 ISMIR Tutorial）</a></h2>
       <p>ISMIR 2024 教程中文翻译版：探索语言模型如何理解和生成音乐，涵盖音乐描述、检索与生成</p>
       <div class="card-links">
+        <a href="https://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247484022&idx=1&sn=94535fbc6c7a56490dd52d11f0962f4d&scene=19&poc_token=HFgzkmmjmF53Hz5-bJCS3mDASmeI4RhAuTrEu65S" target="_blank">公众号文章</a>
         <a href="https://github.com/mulab-mir/music-language-tutorial" target="_blank">英文原版</a>
         <a href="music-language-tutorial/intro.html">中文版在线阅读</a>
       </div>
     </div>
     <!-- 2026-02-14 MIR-CC — has extra links -->
-    <div class="card">
+    <div class="card" data-tag="mir">
       <div class="card-top">
         <span class="tag tag-mir-cc">MIR-CC</span>
         <span class="card-date">2026-02-14</span>
       </div>
-      <h2><a href="https://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247484015&idx=1&sn=ffb0e282814654db668b9aeaae7070e6&scene=19&poc_token=HOHwkGmjA6j2m1IrUPZG7-8YVeVabxBGl9z10Nyt" target="_blank">2026年，用 Claude Code 就可以无痛入门音乐科技</a></h2>
+      <h2><a href="articles/claude-code-mir.html">2026年，用 Claude Code 就可以无痛入门音乐科技</a></h2>
       <p>用 Claude Code + marimo 交互式笔记本，从零开始探索音乐信息检索的核心概念</p>
       <div class="card-links">
+        <a href="https://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247484015&idx=1&sn=ffb0e282814654db668b9aeaae7070e6&scene=19&poc_token=HOHwkGmjA6j2m1IrUPZG7-8YVeVabxBGl9z10Nyt" target="_blank">公众号文章</a>
         <a href="https://github.com/beiciliang/intro2musictech/blob/main/MIR-CC.py" target="_blank">MIR-CC.py</a>
         <a href="MIR-CC.html">在线预览</a>
       </div>
     </div>
     <!-- 2023-03-26 INFO — has extra links -->
-    <div class="card">
+    <div class="card" data-tag="info">
       <div class="card-top">
         <span class="tag tag-info">INFO</span>
         <span class="card-date">2023-03-26</span>
       </div>
-      <h2><a href="https://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483994&idx=1&sn=3dfeefafc11c264106f448379052b42d&chksm=fe0d9cf5c97a15e30a5338b9031ae1741ea45856d234dc02d13ecc7723b5682a747f9c00de31&scene=178&cur_album_id=1342444458121576448#rd" target="_blank">分享我的MIR研发技术栈</a></h2>
+      <h2><a href="articles/mir-tech-stack.html">分享我的MIR研发技术栈</a></h2>
       <div class="card-links">
+        <a href="https://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483994&idx=1&sn=3dfeefafc11c264106f448379052b42d&chksm=fe0d9cf5c97a15e30a5338b9031ae1741ea45856d234dc02d13ecc7723b5682a747f9c00de31&scene=178&cur_album_id=1342444458121576448#rd" target="_blank">公众号文章</a>
         <a href="https://www.bilibili.com/video/BV1MX4y1R7cu/?share_source=copy_web&vd_source=9a7c2143e3aca83788929d6099a36f8f" target="_blank">B站视频</a>
       </div>
     </div>
     <!-- 2022-10-17 INFO -->
-    <a class="card" href="https://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483988&idx=1&sn=d5b6dfa1ab0e460f9abad915838f6e59&chksm=fe0d9cfbc97a15edff8b2f5ac49ca678350bc3af18d6558c6508499703e384f82bca36253ca8&scene=178&cur_album_id=1342444458121576448#rd" target="_blank">
+    <div class="card" data-tag="info">
       <div class="card-top">
         <span class="tag tag-info">INFO</span>
         <span class="card-date">2022-10-17</span>
       </div>
-      <h2>从数据角度聊聊音乐版权版税</h2>
-    </a>
+      <h2><a href="articles/music-copyright.html">从数据角度聊聊音乐版权版税</a></h2>
+      <div class="card-links">
+        <a href="https://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483988&idx=1&sn=d5b6dfa1ab0e460f9abad915838f6e59&chksm=fe0d9cfbc97a15edff8b2f5ac49ca678350bc3af18d6558c6508499703e384f82bca36253ca8&scene=178&cur_album_id=1342444458121576448#rd" target="_blank">公众号文章</a>
+      </div>
+    </div>
     <!-- 2021-09-04 MIR -->
-    <a class="card" href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483966&idx=1&sn=f968b4f55595357afa8f6d483715262d&chksm=fe0d9c91c97a1587f42ce8e52d3cd4eec9ba49cad01680aead1b60d0918c134340ce75e3c469#rd" target="_blank">
+    <div class="card" data-tag="mir">
       <div class="card-top">
         <span class="tag tag-mir">MIR</span>
         <span class="card-date">2021-09-04</span>
       </div>
-      <h2>打破砂锅问到底，不同python库做音频预处理的区别在哪里？</h2>
-    </a>
+      <h2><a href="articles/audio-preprocessing.html">打破砂锅问到底，不同python库做音频预处理的区别在哪里？</a></h2>
+      <div class="card-links">
+        <a href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483966&idx=1&sn=f968b4f55595357afa8f6d483715262d&chksm=fe0d9c91c97a1587f42ce8e52d3cd4eec9ba49cad01680aead1b60d0918c134340ce75e3c469#rd" target="_blank">公众号文章</a>
+      </div>
+    </div>
     <!-- 2021-08-06 INFO — has extra links -->
-    <div class="card">
+    <div class="card" data-tag="info">
       <div class="card-top">
         <span class="tag tag-info">INFO</span>
         <span class="card-date">2021-08-06</span>
       </div>
-      <h2><a href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483960&idx=1&sn=80ce28a10186dab81af2af239df76c8a&chksm=fe0d9c97c97a158114decdbdbe6cc6916c6c81f6fce9f9c52617fc6d0ea8738b9720efe8975a#rd" target="_blank">三分钟认识音乐科技</a></h2>
+      <h2><a href="articles/intro-music-tech.html">三分钟认识音乐科技</a></h2>
       <div class="card-links">
+        <a href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483960&idx=1&sn=80ce28a10186dab81af2af239df76c8a&chksm=fe0d9c97c97a158114decdbdbe6cc6916c6c81f6fce9f9c52617fc6d0ea8738b9720efe8975a#rd" target="_blank">公众号文章</a>
         <a href="https://www.youtube.com/watch?v=YgYV-7-ohxQ" target="_blank">YouTube视频</a>
       </div>
     </div>
     <!-- 2021-06-04 MIR — has extra links -->
-    <div class="card">
+    <div class="card" data-tag="mir">
       <div class="card-top">
         <span class="tag tag-mir">MIR</span>
         <span class="card-date">2021-06-04</span>
       </div>
-      <h2><a href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483954&idx=1&sn=7bdcc70838c0fc3d014cdedec91411b2&chksm=fe0d9c9dc97a158b31d11ec699d6e5ab53caf1897431cdf2f20f73ab67d885790b4a9361f055#rd" target="_blank">当音乐标签化身为音频Embedding时能解决什么？</a></h2>
+      <h2><a href="articles/audio-embedding.html">当音乐标签化身为音频Embedding时能解决什么？</a></h2>
       <div class="card-links">
+        <a href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483954&idx=1&sn=7bdcc70838c0fc3d014cdedec91411b2&chksm=fe0d9c9dc97a158b31d11ec699d6e5ab53caf1897431cdf2f20f73ab67d885790b4a9361f055#rd" target="_blank">公众号文章</a>
         <a href="https://arxiv.org/abs/2010.15389" target="_blank">arXiv论文</a>
       </div>
     </div>
     <!-- 2021-03-06 INFO -->
-    <a class="card" href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483940&idx=1&sn=c6470c7b689da2882ee4fb6c43e1577c&chksm=fe0d9c8bc97a159d2c7734ab466b38d2d524f4e8e2ce87a2d54cf5303ae5c436eadbdd103b09#rd" target="_blank">
+    <div class="card" data-tag="info">
       <div class="card-top">
         <span class="tag tag-info">INFO</span>
         <span class="card-date">2021-03-06</span>
       </div>
-      <h2>2020年度那些亮眼的音乐科技成就</h2>
-    </a>
+      <h2><a href="articles/music-tech-2020.html">2020年度那些亮眼的音乐科技成就</a></h2>
+      <div class="card-links">
+        <a href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483940&idx=1&sn=c6470c7b689da2882ee4fb6c43e1577c&chksm=fe0d9c8bc97a159d2c7734ab466b38d2d524f4e8e2ce87a2d54cf5303ae5c436eadbdd103b09#rd" target="_blank">公众号文章</a>
+      </div>
+    </div>
     <!-- 2020-10-08 MIR -->
-    <a class="card" href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483923&idx=1&sn=2fe1ad96ba0b764888f28fdd88ce9e36&chksm=fe0d9cbcc97a15aa70632d73d3d7cafbc63d97027d8a9d1ecd7fee20212649d6b1fbde37c90f#rd" target="_blank">
+    <div class="card" data-tag="mir">
       <div class="card-top">
         <span class="tag tag-mir">MIR</span>
         <span class="card-date">2020-10-08</span>
       </div>
-      <h2>音乐流派自动识别的前世今生</h2>
-    </a>
+      <h2><a href="articles/music-genre.html">音乐流派自动识别的前世今生</a></h2>
+      <div class="card-links">
+        <a href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483923&idx=1&sn=2fe1ad96ba0b764888f28fdd88ce9e36&chksm=fe0d9cbcc97a15aa70632d73d3d7cafbc63d97027d8a9d1ecd7fee20212649d6b1fbde37c90f#rd" target="_blank">公众号文章</a>
+      </div>
+    </div>
     <!-- 2020-05-16 说得好听 — has extra links -->
-    <div class="card">
+    <div class="card" data-tag="other">
       <div class="card-top">
         <span class="tag tag-podcast">说得好听</span>
         <span class="card-date">2020-05-16</span>
       </div>
-      <h2><a href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483914&idx=1&sn=1a474f9bdfb1c7981a461151737bb5e0&chksm=fe0d9ca5c97a15b36c77c5879d916cb7f2a56c62741c3490dd1c18c5f638231452e9929e398f#rd" target="_blank">EP7-音乐推荐算法的小秘密</a></h2>
+      <h2><a href="articles/podcast-ep7.html">EP7-音乐推荐算法的小秘密</a></h2>
       <div class="card-links">
+        <a href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483914&idx=1&sn=1a474f9bdfb1c7981a461151737bb5e0&chksm=fe0d9ca5c97a15b36c77c5879d916cb7f2a56c62741c3490dd1c18c5f638231452e9929e398f#rd" target="_blank">公众号文章</a>
         <a href="https://www.xiaoyuzhoufm.com/episode/5ebeec95418a84a0468f2ed5" target="_blank">小宇宙播客</a>
       </div>
     </div>
     <!-- 2020-04-30 INFO -->
-    <a class="card" href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483904&idx=1&sn=959fd70b768b9416a5065748ba6f5818&chksm=fe0d9cafc97a15b9c1123a30af34497d5e79e5b636a15a70ad169434ed5b0cf937f13ca87a7b#rd" target="_blank">
+    <div class="card" data-tag="info">
       <div class="card-top">
         <span class="tag tag-info">INFO</span>
         <span class="card-date">2020-04-30</span>
       </div>
-      <h2>《音频音乐技术》正式出版</h2>
-    </a>
+      <h2><a href="articles/audio-music-tech-book.html">《音频音乐技术》正式出版</a></h2>
+      <div class="card-links">
+        <a href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483904&idx=1&sn=959fd70b768b9416a5065748ba6f5818&chksm=fe0d9cafc97a15b9c1123a30af34497d5e79e5b636a15a70ad169434ed5b0cf937f13ca87a7b#rd" target="_blank">公众号文章</a>
+      </div>
+    </div>
     <!-- 2020-03-20 MIR -->
-    <a class="card" href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483898&idx=1&sn=3a405119a32714442c8dcd9be830cdb9&chksm=fe0d9f55c97a1643a091acb7d6c25c14a8d19d107f9d430ffd9055a468f4d18c43666b2c260f#rd" target="_blank">
+    <div class="card" data-tag="mir">
       <div class="card-top">
         <span class="tag tag-mir">MIR</span>
         <span class="card-date">2020-03-20</span>
       </div>
-      <h2>震惊! AI发现这些歌竟然...</h2>
-    </a>
+      <h2><a href="articles/ai-music-discovery.html">震惊! AI发现这些歌竟然...</a></h2>
+      <div class="card-links">
+        <a href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483898&idx=1&sn=3a405119a32714442c8dcd9be830cdb9&chksm=fe0d9f55c97a1643a091acb7d6c25c14a8d19d107f9d430ffd9055a468f4d18c43666b2c260f#rd" target="_blank">公众号文章</a>
+      </div>
+    </div>
     <!-- 2020-03-14 MIR -->
-    <a class="card" href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483885&idx=1&sn=f9e4c9f71451575d1111e566943f4aff&chksm=fe0d9f42c97a16544b35edd490294e754e9e3cf48a13ca6585bcb7f58c02d0c1bf0222822793#rd" target="_blank">
+    <div class="card" data-tag="mir">
       <div class="card-top">
         <span class="tag tag-mir">MIR</span>
         <span class="card-date">2020-03-14</span>
       </div>
-      <h2>音乐推荐: 努力懂你的预言家</h2>
-    </a>
+      <h2><a href="articles/music-recommendation.html">音乐推荐: 努力懂你的预言家</a></h2>
+      <div class="card-links">
+        <a href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483885&idx=1&sn=f9e4c9f71451575d1111e566943f4aff&chksm=fe0d9f42c97a16544b35edd490294e754e9e3cf48a13ca6585bcb7f58c02d0c1bf0222822793#rd" target="_blank">公众号文章</a>
+      </div>
+    </div>
     <!-- 2020-03-07 MIR — has extra links -->
-    <div class="card">
+    <div class="card" data-tag="mir">
       <div class="card-top">
         <span class="tag tag-mir">MIR</span>
         <span class="card-date">2020-03-07</span>
       </div>
-      <h2><a href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483818&idx=1&sn=db17b69603b98532f993f7f094248ce3&chksm=fe0d9f05c97a16139ee4114ed6890c8d99bd2c09210aa7ba0d085a2f44599e5cbd5a93375290#rd" target="_blank">听歌识曲: 音乐宇宙里的占星师</a></h2>
+      <h2><a href="articles/audio-fingerprint.html">听歌识曲: 音乐宇宙里的占星师</a></h2>
       <div class="card-links">
+        <a href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483818&idx=1&sn=db17b69603b98532f993f7f094248ce3&chksm=fe0d9f05c97a16139ee4114ed6890c8d99bd2c09210aa7ba0d085a2f44599e5cbd5a93375290#rd" target="_blank">公众号文章</a>
         <a href="https://zhuanlan.zhihu.com/p/75360272" target="_blank">知乎系列文章</a>
       </div>
     </div>
     <!-- 2020-01-12 INFO -->
-    <a class="card" href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483802&idx=1&sn=9790d92e685baa74f28f3053c4ff15ef&chksm=fe0d9f35c97a1623fc305ce8c79b19e7451f5500d95b08c4fd5c27e47c8a256094c3e2022066#rd" target="_blank">
+    <div class="card" data-tag="info">
       <div class="card-top">
         <span class="tag tag-info">INFO</span>
         <span class="card-date">2020-01-12</span>
       </div>
-      <h2>2019年度那些亮眼的音乐科技成就</h2>
-    </a>
+      <h2><a href="articles/music-tech-2019.html">2019年度那些亮眼的音乐科技成就</a></h2>
+      <div class="card-links">
+        <a href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483802&idx=1&sn=9790d92e685baa74f28f3053c4ff15ef&chksm=fe0d9f35c97a1623fc305ce8c79b19e7451f5500d95b08c4fd5c27e47c8a256094c3e2022066#rd" target="_blank">公众号文章</a>
+      </div>
+    </div>
     <!-- 2019-11-13 MIR -->
-    <a class="card" href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483792&idx=1&sn=38b07d6efff4523eecd78366f3e87962&chksm=fe0d9f3fc97a1629669c5875ea33a3b43878a2859e71a052c7c38b212127fea936e935e79c75#rd" target="_blank">
+    <div class="card" data-tag="mir">
       <div class="card-top">
         <span class="tag tag-mir">MIR</span>
         <span class="card-date">2019-11-13</span>
       </div>
-      <h2>音频特征小全之提取工具</h2>
-    </a>
+      <h2><a href="articles/audio-feature-tools.html">音频特征小全之提取工具</a></h2>
+      <div class="card-links">
+        <a href="http://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483792&idx=1&sn=38b07d6efff4523eecd78366f3e87962&chksm=fe0d9f3fc97a1629669c5875ea33a3b43878a2859e71a052c7c38b212127fea936e935e79c75#rd" target="_blank">公众号文章</a>
+      </div>
+    </div>
     <!-- 2019-08-19 INFO -->
-    <a class="card" href="https://mp.weixin.qq.com/s/N4p_jmsuY6RVuz1IjrSMeg" target="_blank">
+    <div class="card" data-tag="info">
       <div class="card-top">
         <span class="tag tag-info">INFO</span>
         <span class="card-date">2019-08-19</span>
       </div>
-      <h2>在C4DM读博是怎样一番体验？</h2>
-    </a>
+      <h2><a href="articles/c4dm-phd.html">在C4DM读博是怎样一番体验？</a></h2>
+      <div class="card-links">
+        <a href="https://mp.weixin.qq.com/s/N4p_jmsuY6RVuz1IjrSMeg" target="_blank">公众号文章</a>
+      </div>
+    </div>
     <!-- 2019-02-18 INFO -->
-    <a class="card" href="https://mp.weixin.qq.com/s/RkcOyFf4eLIe512B37nmIw" target="_blank">
+    <div class="card" data-tag="info">
       <div class="card-top">
         <span class="tag tag-info">INFO</span>
         <span class="card-date">2019-02-18</span>
       </div>
-      <h2>C4DM在ICASSP 2019的收录成果</h2>
-    </a>
+      <h2><a href="articles/c4dm-icassp2019.html">C4DM在ICASSP 2019的收录成果</a></h2>
+      <div class="card-links">
+        <a href="https://mp.weixin.qq.com/s/RkcOyFf4eLIe512B37nmIw" target="_blank">公众号文章</a>
+      </div>
+    </div>
     <!-- 2018-12-17 INFO -->
-    <a class="card" href="https://mp.weixin.qq.com/s/5FBzxHm1PcgBpHy6645JmA" target="_blank">
+    <div class="card" data-tag="info">
       <div class="card-top">
         <span class="tag tag-info">INFO</span>
         <span class="card-date">2018-12-17</span>
       </div>
-      <h2>2018年度那些亮眼的音乐科技成就</h2>
-    </a>
+      <h2><a href="articles/music-tech-2018.html">2018年度那些亮眼的音乐科技成就</a></h2>
+      <div class="card-links">
+        <a href="https://mp.weixin.qq.com/s/5FBzxHm1PcgBpHy6645JmA" target="_blank">公众号文章</a>
+      </div>
+    </div>
     <!-- 2018-11-30 INFO -->
-    <a class="card" href="https://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483761&idx=1&sn=52b81b9fca161df1afad2a8babad251a&scene=19#wechat_redirect" target="_blank">
+    <div class="card" data-tag="info">
       <div class="card-top">
         <span class="tag tag-info">INFO</span>
         <span class="card-date">2018-11-30</span>
       </div>
-      <h2>音乐科技相关会议期刊列表</h2>
-    </a>
+      <h2><a href="articles/conferences-journals.html">音乐科技相关会议期刊列表</a></h2>
+      <div class="card-links">
+        <a href="https://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483761&idx=1&sn=52b81b9fca161df1afad2a8babad251a&scene=19#wechat_redirect" target="_blank">公众号文章</a>
+      </div>
+    </div>
     <!-- 2018-11-24 MIR — has extra links -->
-    <div class="card">
+    <div class="card" data-tag="mir">
       <div class="card-top">
         <span class="tag tag-mir">MIR</span>
         <span class="card-date">2018-11-24</span>
       </div>
-      <h2><a href="https://mp.weixin.qq.com/s/XqZvZ4-m3xd81udyUSg4wg" target="_blank">音频特征小全之乐音特征</a></h2>
+      <h2><a href="articles/audio-feature-musical.html">音频特征小全之乐音特征</a></h2>
       <div class="card-links">
+        <a href="https://mp.weixin.qq.com/s/XqZvZ4-m3xd81udyUSg4wg" target="_blank">公众号文章</a>
         <a href="https://github.com/beiciliang/intro2musictech/blob/main/MIR-02_4.ipynb" target="_blank">MIR-02_4.ipynb</a>
       </div>
     </div>
     <!-- 2018-10-14 MIR — has extra links -->
-    <div class="card">
+    <div class="card" data-tag="mir">
       <div class="card-top">
         <span class="tag tag-mir">MIR</span>
         <span class="card-date">2018-10-14</span>
       </div>
-      <h2><a href="https://mp.weixin.qq.com/s/TOAXROVlOVYDmVlmFIyBxQ" target="_blank">音频特征小全之频域特征</a></h2>
+      <h2><a href="articles/audio-feature-frequency.html">音频特征小全之频域特征</a></h2>
       <div class="card-links">
+        <a href="https://mp.weixin.qq.com/s/TOAXROVlOVYDmVlmFIyBxQ" target="_blank">公众号文章</a>
         <a href="https://github.com/beiciliang/intro2musictech/blob/main/MIR-02_3.ipynb" target="_blank">MIR-02_3.ipynb</a>
       </div>
     </div>
     <!-- 2018-09-13 MIR — has extra links -->
-    <div class="card">
+    <div class="card" data-tag="mir">
       <div class="card-top">
         <span class="tag tag-mir">MIR</span>
         <span class="card-date">2018-09-13</span>
       </div>
-      <h2><a href="https://mp.weixin.qq.com/s/fwbxA0ZWJPuOKolouQea3Q" target="_blank">音频特征小全之时域特征</a></h2>
+      <h2><a href="articles/audio-feature-time.html">音频特征小全之时域特征</a></h2>
       <div class="card-links">
+        <a href="https://mp.weixin.qq.com/s/fwbxA0ZWJPuOKolouQea3Q" target="_blank">公众号文章</a>
         <a href="https://github.com/beiciliang/intro2musictech/blob/main/MIR-02_2.ipynb" target="_blank">MIR-02_2.ipynb</a>
       </div>
     </div>
     <!-- 2018-08-27 NIME — has extra links -->
-    <div class="card">
+    <div class="card" data-tag="nime">
       <div class="card-top">
         <span class="tag tag-nime">NIME</span>
         <span class="card-date">2018-08-27</span>
       </div>
-      <h2><a href="https://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483718&idx=1&sn=fbf3f7c11e61096bafd72ea6ed0c0e8a&scene=19#wechat_redirect" target="_blank">为什么说钢琴是乐器之王？复杂！</a></h2>
+      <h2><a href="articles/piano-complexity.html">为什么说钢琴是乐器之王？复杂！</a></h2>
       <div class="card-links">
+        <a href="https://mp.weixin.qq.com/s?__biz=MzU5MzY3NzI0OA==&mid=2247483718&idx=1&sn=fbf3f7c11e61096bafd72ea6ed0c0e8a&scene=19#wechat_redirect" target="_blank">公众号文章</a>
         <a href="https://www.zhihu.com/question/288614974" target="_blank">知乎问题</a>
       </div>
     </div>
     <!-- 2018-08-22 INFO — has extra links -->
-    <div class="card">
+    <div class="card" data-tag="info">
       <div class="card-top">
         <span class="tag tag-info">INFO</span>
         <span class="card-date">2018-08-22</span>
       </div>
-      <h2><a href="https://mp.weixin.qq.com/s/2nDWikda9fh2x5o093F6HA" target="_blank">音乐科技相关科研组列表</a></h2>
+      <h2><a href="articles/research-groups.html">音乐科技相关科研组列表</a></h2>
       <div class="card-links">
+        <a href="https://mp.weixin.qq.com/s/2nDWikda9fh2x5o093F6HA" target="_blank">公众号文章</a>
         <a href="https://github.com/beiciliang/intro2musictech/blob/main/INFO-ResearchGroups.md" target="_blank">INFO-ResearchGroups.md</a>
       </div>
     </div>
     <!-- 2018-08-18 MIR — has extra links -->
-    <div class="card">
+    <div class="card" data-tag="mir">
       <div class="card-top">
         <span class="tag tag-mir">MIR</span>
         <span class="card-date">2018-08-18</span>
       </div>
-      <h2><a href="https://mp.weixin.qq.com/s/oFrW7hmZgmAuZGIVHjZTAQ" target="_blank">音频特征小全之概览</a></h2>
+      <h2><a href="articles/audio-feature-overview.html">音频特征小全之概览</a></h2>
       <div class="card-links">
+        <a href="https://mp.weixin.qq.com/s/oFrW7hmZgmAuZGIVHjZTAQ" target="_blank">公众号文章</a>
         <a href="https://github.com/beiciliang/intro2musictech/blob/main/MIR-02_1.ipynb" target="_blank">MIR-02_1.ipynb</a>
       </div>
     </div>
     <!-- 2018-08-11 NIME — has extra links -->
-    <div class="card">
+    <div class="card" data-tag="nime">
       <div class="card-top">
         <span class="tag tag-nime">NIME</span>
         <span class="card-date">2018-08-11</span>
       </div>
-      <h2><a href="https://mp.weixin.qq.com/s/X05DgjhXO7oMf8Gej5P3Mw" target="_blank">日常物件在没有成精的前提下如何发声儿？</a></h2>
+      <h2><a href="articles/bela-everyday-objects.html">日常物件在没有成精的前提下如何发声儿？</a></h2>
       <div class="card-links">
+        <a href="https://mp.weixin.qq.com/s/X05DgjhXO7oMf8Gej5P3Mw" target="_blank">公众号文章</a>
         <a href="http://blog.bela.io/" target="_blank">The Bela Blog</a>
       </div>
     </div>
     <!-- 2018-08-05 MIR — has extra links -->
-    <div class="card">
+    <div class="card" data-tag="mir">
       <div class="card-top">
         <span class="tag tag-mir">MIR</span>
         <span class="card-date">2018-08-05</span>
       </div>
-      <h2><a href="https://mp.weixin.qq.com/s/pvpFoKKa0Ki_uZ3Y6rqaJw" target="_blank">要把音乐画出来，总共分几步？</a></h2>
+      <h2><a href="articles/music-visualization.html">要把音乐画出来，总共分几步？</a></h2>
       <div class="card-links">
+        <a href="https://mp.weixin.qq.com/s/pvpFoKKa0Ki_uZ3Y6rqaJw" target="_blank">公众号文章</a>
         <a href="https://github.com/beiciliang/intro2musictech/blob/main/MIR-01.ipynb" target="_blank">MIR-01.ipynb</a>
       </div>
     </div>
     <!-- 2018-08-03 NIME -->
-    <a class="card" href="https://mp.weixin.qq.com/s/vUU30Ap5ot-Ygpy8eBeC4w" target="_blank">
+    <div class="card" data-tag="nime">
       <div class="card-top">
         <span class="tag tag-nime">NIME</span>
         <span class="card-date">2018-08-03</span>
       </div>
-      <h2>那些为身障人士设计的乐器</h2>
-    </a>
+      <h2><a href="articles/accessible-instruments.html">那些为身障人士设计的乐器</a></h2>
+      <div class="card-links">
+        <a href="https://mp.weixin.qq.com/s/vUU30Ap5ot-Ygpy8eBeC4w" target="_blank">公众号文章</a>
+      </div>
+    </div>
     <!-- 2018-07-28 SETUP — has extra links -->
-    <div class="card">
+    <div class="card" data-tag="other">
       <div class="card-top">
         <span class="tag tag-setup">SETUP</span>
         <span class="card-date">2018-07-28</span>
       </div>
-      <h2><a href="https://mp.weixin.qq.com/s/ngvmPl5S7QI-PqUUBtbQ3w" target="_blank">从零设置编程环境</a></h2>
+      <h2><a href="articles/setup-environment.html">从零设置编程环境</a></h2>
       <div class="card-links">
+        <a href="https://mp.weixin.qq.com/s/ngvmPl5S7QI-PqUUBtbQ3w" target="_blank">公众号文章</a>
         <a href="https://github.com/beiciliang/intro2musictech/blob/main/00-Hello.ipynb" target="_blank">00-Hello.ipynb</a>
       </div>
     </div>
     <!-- 2018-07-27 README -->
-    <a class="card" href="https://mp.weixin.qq.com/s/S8Q5iSUMgKZQ5g-17dF8UA" target="_blank">
+    <div class="card" data-tag="other">
       <div class="card-top">
         <span class="tag tag-readme">README</span>
         <span class="card-date">2018-07-27</span>
       </div>
-      <h2>无痛入门音乐科技门槛须知</h2>
-    </a>
+      <h2><a href="articles/readme-intro.html">无痛入门音乐科技门槛须知</a></h2>
+      <div class="card-links">
+        <a href="https://mp.weixin.qq.com/s/S8Q5iSUMgKZQ5g-17dF8UA" target="_blank">公众号文章</a>
+      </div>
+    </div>
+    </div>
   </main>
 
+  <script>
+    document.querySelector('.filters').addEventListener('click', function(e) {
+      if (!e.target.classList.contains('filter-btn')) return;
+      document.querySelectorAll('.filter-btn').forEach(function(b) { b.classList.remove('active'); });
+      e.target.classList.add('active');
+      var filter = e.target.getAttribute('data-filter');
+      document.querySelectorAll('.card').forEach(function(card) {
+        card.classList.toggle('hidden', filter !== 'all' && card.getAttribute('data-tag') !== filter);
+      });
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Add 32 standalone HTML pages in `articles/` extracted from WeChat public account articles, with polished styling:
  - Code block rendering (monospace font, proper background, reset nested WeChat elements)
  - Paragraph spacing (`<section>` margin, empty element cleanup)
  - Centered section titles (h2/h3 with `『』`)
  - Clickable plain-text URLs (`target="_blank"`)
  - Removed broken video/audio embeds, empty bullet artifacts, and "阅读原文" dead links
  - Fixed broken long URLs in `music-tech-2018.html`
  - Reformatted paper entries in `c4dm-icassp2019.html` with line breaks
  - Rebuilt `audio-music-tech-book.html` with clean semantic TOC structure
- Add a sticky vertical filter sidebar to `index.html` with categories: 全部, MIR, INFO, TECH, NIME, OTHER
- Responsive: collapses to horizontal pills on mobile (< 640px)
- All HTML files formatted with Prettier

## Test plan

- [ ] Open https://beiciliang.github.io/intro2musictech/ and verify filter buttons work
- [ ] Click each filter category and confirm correct cards shown
- [ ] Scroll down and verify sidebar stays sticky
- [ ] Open several article pages and verify content renders correctly
- [ ] Test on mobile viewport — filter should be horizontal